### PR TITLE
feat(v0.4-alpha): deterministic baseline benchmark harness (F-057, shadow-only)

### DIFF
--- a/eval/pyproject.toml
+++ b/eval/pyproject.toml
@@ -12,6 +12,9 @@ dependencies = []
 # Not required to run `python eval/run_fidelity.py --gate ...`.
 # Reserved for future test suites around the harness itself.
 dev = ["pytest>=7"]
+# Exact provider-token ceilings for `run_baselines.py` (v0.4 research harness). Optional:
+# without it the harness falls back to tokenfold-core's byte/4 heuristic and labels the report.
+exact = ["tiktoken>=0.7"]
 
 [build-system]
 requires = ["setuptools>=61"]

--- a/eval/run_baselines.py
+++ b/eval/run_baselines.py
@@ -1,0 +1,380 @@
+#!/usr/bin/env python3
+"""v0.4-alpha learned-selector *baseline* harness (F-057, shadow-only).
+
+This is the "baselines first" stage of the v0.4 research plan in
+`docs/solution-design/model-research.md`: before any model is trained, it runs a set of
+deterministic keep/drop selectors over paired downstream tasks at *exact provider-token
+ceilings* and reports an achieved-token / task-score curve. There is no ML here and nothing
+is written to any served path — a learned selector will later plug in as just another entry
+in `SELECTORS` and be measured against these same baselines.
+
+Design mirrors `run_fidelity.py`: standard-library only, JSON fixtures under `eval/tasks/`.
+`tiktoken` is an *optional* import — when present, token ceilings are exact (`o200k_base`);
+otherwise a byte/4 heuristic (identical to `tokenfold-core`'s fallback) is used and the report
+labels itself accordingly. Nothing here touches the shipped Rust/npm/Python runtime.
+
+Deliberately deferred (documented, not hidden — see `eval/tasks/v04/README.md`):
+  - RTK, RTK+tokenfold, deterministic-tokenfold (Rust CLI subprocess), LLMLingua-style, and the
+    unmodified Headroom Kompress-v2 achieved-token sweep are additional `SELECTORS` entries.
+  - Real Tier-B public-repo corpora and project-disjoint train/test splits.
+  - Structural (diff-hunk / JSON-container / AST) segmentation; v0.4-alpha segments by line.
+  - An LLM judge for task success (the current scorer is a deterministic containment proxy).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import re
+import sys
+from pathlib import Path
+
+# --- token counting: exact via tiktoken when available, else the core's byte/4 heuristic ------
+
+try:  # pragma: no cover - depends on the local environment
+    import tiktoken
+
+    _ENC = tiktoken.get_encoding("o200k_base")
+
+    def count_tokens(text: str) -> int:
+        return len(_ENC.encode(text)) if text else 0
+
+    TOKENIZER = {"backend": "tiktoken", "model": "o200k_base", "is_exact": True}
+except Exception:  # pragma: no cover - exercised only without tiktoken installed
+
+    def count_tokens(text: str) -> int:
+        # Mirrors tokenfold-core's ByteHeuristicEstimator: ceil(bytes / 4), 0 for empty.
+        if not text:
+            return 0
+        return -(-len(text.encode("utf-8")) // 4)
+
+    TOKENIZER = {"backend": "heuristic", "model": None, "is_exact": False}
+
+
+# --- segmentation + deterministic forcing -----------------------------------------------------
+
+
+def segment(source: str) -> list[str]:
+    """Atomic source units. v0.4-alpha uses line units (newline kept, so kept units reassemble
+    byte-for-byte). Structural/diff/JSON/AST segmentation is deferred."""
+    return source.splitlines(keepends=True)
+
+
+def forced_indices(units: list[str], critical_atoms: list[str]) -> set[int]:
+    """Units containing any declared critical atom are force-kept, regardless of the selector.
+
+    This is the deterministic layer that makes 100% critical-atom survival a *structural*
+    guarantee (a hard gate in model-research.md) rather than something a learned model must get
+    right. A learned selector only ever ranks the *remaining* units."""
+    return {
+        i
+        for i, unit in enumerate(units)
+        if any(atom and atom in unit for atom in critical_atoms)
+    }
+
+
+_WORD = re.compile(r"[A-Za-z0-9_]+")
+
+
+def _tokens(text: str) -> list[str]:
+    return [w.lower() for w in _WORD.findall(text)]
+
+
+# --- deterministic baseline selectors ---------------------------------------------------------
+# Each returns a salience score per unit index (higher = keep sooner). The allocator forces
+# critical units first, then fills the remaining token budget by descending score.
+
+
+def sel_keep_all(units: list[str], query: str) -> list[float]:
+    return [math.inf] * len(units)
+
+
+def sel_forced_only(units: list[str], query: str) -> list[float]:
+    return [-math.inf] * len(units)
+
+
+def sel_recency(units: list[str], query: str) -> list[float]:
+    # Prefer later units (classic for logs/streams).
+    return [float(i) for i in range(len(units))]
+
+
+def sel_frequency(units: list[str], query: str) -> list[float]:
+    """Query-independent: prefer units carrying *rare* tokens, drop repetitive boilerplate.
+    A unit's score is the sum over its distinct tokens of 1/document-frequency."""
+    df: dict[str, int] = {}
+    for unit in units:
+        for tok in set(_tokens(unit)):
+            df[tok] = df.get(tok, 0) + 1
+    scores = []
+    for unit in units:
+        distinct = set(_tokens(unit))
+        scores.append(sum(1.0 / df[t] for t in distinct) if distinct else 0.0)
+    return scores
+
+
+def sel_bm25(units: list[str], query: str) -> list[float]:
+    """Okapi BM25 relevance of each unit to the task query (k1=1.5, b=0.75). Query-dependent."""
+    k1, b = 1.5, 0.75
+    docs = [_tokens(u) for u in units]
+    q = set(_tokens(query))
+    if not q or not units:
+        return [0.0] * len(units)
+    n = len(docs)
+    avgdl = sum(len(d) for d in docs) / n if n else 0.0
+    df: dict[str, int] = {}
+    for d in docs:
+        for t in set(d):
+            if t in q:
+                df[t] = df.get(t, 0) + 1
+    scores = []
+    for d in docs:
+        dl = len(d)
+        s = 0.0
+        for t in q:
+            if t not in df:
+                continue
+            tf = d.count(t)
+            if tf == 0:
+                continue
+            idf = math.log(1 + (n - df[t] + 0.5) / (df[t] + 0.5))
+            s += idf * (tf * (k1 + 1)) / (tf + k1 * (1 - b + b * (dl / avgdl if avgdl else 0)))
+        scores.append(s)
+    return scores
+
+
+SELECTORS = {
+    "keep_all": sel_keep_all,
+    "forced_only": sel_forced_only,
+    "recency": sel_recency,
+    "frequency": sel_frequency,
+    "bm25": sel_bm25,
+}
+
+
+# --- token-ceiling allocator ------------------------------------------------------------------
+
+
+def allocate(
+    units: list[str],
+    forced: set[int],
+    scores: list[float],
+    budget_tokens: int,
+    keep_all: bool,
+) -> list[int]:
+    """Force critical units, then greedily add the highest-scored eligible units whose inclusion
+    keeps the *re-tokenized full candidate* within `budget_tokens`.
+
+    Per model-research.md the ceiling is checked on the assembled candidate, not by summing
+    per-unit estimates (subword merges make per-unit costs non-additive). ponytail: re-tokenizes
+    the whole candidate each step -> O(n^2) tokenization; fine for fixtures, batch/increment for
+    large corpora."""
+    n = len(units)
+    if keep_all:
+        return list(range(n))
+
+    kept = set(forced)
+
+    def cost(idxs: set[int]) -> int:
+        return count_tokens("".join(units[i] for i in sorted(idxs)))
+
+    # Ranked non-forced units: score desc, original order as a stable tie-break.
+    candidates = sorted(
+        (i for i in range(n) if i not in forced),
+        key=lambda i: (-scores[i], i),
+    )
+    for i in candidates:
+        if scores[i] == -math.inf:
+            break  # forced_only: nothing beyond the floor
+        trial = kept | {i}
+        if cost(trial) <= budget_tokens:
+            kept = trial
+    return sorted(kept)
+
+
+# --- task scoring (deterministic proxy) -------------------------------------------------------
+
+
+def score_task(kept_text: str, fixture: dict) -> dict:
+    """Deterministic proxy for downstream task success: every critical atom present AND the gold
+    answer span present in the retained context. Not an LLM judge (which model-research.md
+    reserves for diagnosing failures, never for satisfying a gate)."""
+    atoms = fixture.get("critical_atoms", [])
+    survived = sum(1 for a in atoms if a in kept_text)
+    atom_survival = survived / len(atoms) if atoms else 1.0
+    gold = fixture.get("gold_answer")
+    answer_present = 1.0 if (not gold or gold in kept_text) else 0.0
+    success = 1.0 if atom_survival == 1.0 and answer_present == 1.0 else 0.0
+    return {
+        "task_success": success,
+        "critical_atom_survival": atom_survival,
+        "answer_present": answer_present,
+    }
+
+
+# --- one run + aggregation --------------------------------------------------------------------
+
+
+def run_one(fixture: dict, baseline: str, target_ratio: float) -> dict:
+    source = fixture["source"]
+    units = segment(source)
+    raw_tokens = count_tokens(source)
+    budget = round(raw_tokens * target_ratio)
+    atoms = fixture.get("critical_atoms", [])
+    forced = forced_indices(units, atoms)
+    scores = SELECTORS[baseline](units, fixture.get("query", ""))
+    kept = allocate(units, forced, scores, budget, keep_all=(baseline == "keep_all"))
+    kept_text = "".join(units[i] for i in kept)
+    achieved = count_tokens(kept_text)
+    forced_floor = count_tokens("".join(units[i] for i in sorted(forced)))
+    result = {
+        "baseline": baseline,
+        "fixture": fixture["id"],
+        "family": fixture.get("family"),
+        "target_ratio": target_ratio,
+        "raw_tokens": raw_tokens,
+        "budget_tokens": budget,
+        "achieved_tokens": achieved,
+        "achieved_ratio": round(achieved / raw_tokens, 4) if raw_tokens else 0.0,
+        "forced_floor_tokens": forced_floor,
+        # keep_all is the uncompressed upper bound, not subject to the ceiling.
+        "over_budget": baseline != "keep_all" and achieved > budget,
+    }
+    result.update(score_task(kept_text, fixture))
+    return result
+
+
+def _mean(xs: list[float]) -> float:
+    return round(sum(xs) / len(xs), 4) if xs else 0.0
+
+
+def build_report(fixtures: list[dict], ratios: list[float]) -> dict:
+    rows = [
+        run_one(fx, name, r)
+        for name in SELECTORS
+        for r in ratios
+        for fx in fixtures
+    ]
+    summary = []
+    for name in SELECTORS:
+        for r in ratios:
+            group = [x for x in rows if x["baseline"] == name and x["target_ratio"] == r]
+            summary.append(
+                {
+                    "baseline": name,
+                    "target_ratio": r,
+                    "mean_task_success": _mean([x["task_success"] for x in group]),
+                    "mean_critical_atom_survival": _mean(
+                        [x["critical_atom_survival"] for x in group]
+                    ),
+                    "mean_achieved_ratio": _mean([x["achieved_ratio"] for x in group]),
+                    "over_budget_count": sum(1 for x in group if x["over_budget"]),
+                }
+            )
+    return {
+        "harness": "v0.4-alpha-baselines",
+        "tokenizer": TOKENIZER,
+        "fixture_count": len(fixtures),
+        "baselines": list(SELECTORS),
+        "ratios": ratios,
+        "summary": summary,
+        "rows": rows,
+    }
+
+
+# --- fixtures + CLI ---------------------------------------------------------------------------
+
+
+def load_fixtures(tasks_dir: Path) -> list[dict]:
+    fixtures = []
+    for path in sorted(tasks_dir.glob("*.json")):
+        fixtures.append(json.loads(path.read_text(encoding="utf-8")))
+    return fixtures
+
+
+def run_gate(fixtures: list[dict], ratios: list[float]) -> int:
+    """Assert the invariants v0.4-alpha guarantees by construction. Returns process exit code."""
+    failures = []
+    for fx in fixtures:
+        for r in ratios:
+            for name in SELECTORS:
+                res = run_one(fx, name, r)
+                # 1. Deterministic forcing => 100% critical-atom survival for every selector.
+                if res["critical_atom_survival"] != 1.0:
+                    failures.append(
+                        f"{name}/{fx['id']}@{r}: critical_atom_survival="
+                        f"{res['critical_atom_survival']} (must be 1.0)"
+                    )
+                # 2. Ceiling respected (unless the forced floor alone exceeds the budget).
+                if (
+                    name != "keep_all"
+                    and res["achieved_tokens"] > res["budget_tokens"]
+                    and res["forced_floor_tokens"] <= res["budget_tokens"]
+                ):
+                    failures.append(
+                        f"{name}/{fx['id']}@{r}: achieved {res['achieved_tokens']} > budget "
+                        f"{res['budget_tokens']} while floor fit"
+                    )
+            # 3. keep_all is the upper bound: full task success.
+            top = run_one(fx, "keep_all", r)
+            if top["task_success"] != 1.0:
+                failures.append(f"keep_all/{fx['id']}@{r}: task_success != 1.0")
+
+    artifact = {
+        "gate": "pass" if not failures else "fail",
+        "tokenizer": TOKENIZER,
+        "checked": len(fixtures) * len(ratios) * len(SELECTORS),
+        "failures": failures,
+    }
+    print(json.dumps(artifact, indent=2))
+    return 0 if not failures else 1
+
+
+def _print_summary(report: dict) -> None:
+    print(f"# v0.4-alpha baselines  (tokenizer: {report['tokenizer']['backend']})")
+    print(f"# {report['fixture_count']} fixtures  ratios={report['ratios']}\n")
+    print(f"{'baseline':<13}{'ratio':>6}{'task':>7}{'crit':>7}{'achieved':>10}{'over':>6}")
+    for s in report["summary"]:
+        print(
+            f"{s['baseline']:<13}{s['target_ratio']:>6}{s['mean_task_success']:>7}"
+            f"{s['mean_critical_atom_survival']:>7}{s['mean_achieved_ratio']:>10}"
+            f"{s['over_budget_count']:>6}"
+        )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description="v0.4-alpha deterministic baseline harness")
+    p.add_argument(
+        "--tasks-dir",
+        default=str(Path(__file__).parent / "tasks" / "v04"),
+        help="directory of paired-task fixtures",
+    )
+    p.add_argument(
+        "--ratios",
+        default="0.5,0.25",
+        help="comma-separated target token-retention ratios (default: 0.5,0.25)",
+    )
+    p.add_argument("--gate", action="store_true", help="assert invariants; exit non-zero on fail")
+    p.add_argument("--json", action="store_true", help="print the full JSON report")
+    return p
+
+
+def main(argv=None) -> int:
+    args = build_parser().parse_args(argv)
+    ratios = [float(x) for x in args.ratios.split(",") if x.strip()]
+    fixtures = load_fixtures(Path(args.tasks_dir))
+    if not fixtures:
+        print(f"no fixtures found in {args.tasks_dir}", file=sys.stderr)
+        return 2
+    if args.gate:
+        return run_gate(fixtures, ratios)
+    report = build_report(fixtures, ratios)
+    if args.json:
+        print(json.dumps(report, indent=2))
+    else:
+        _print_summary(report)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/eval/tasks/v04/README.md
+++ b/eval/tasks/v04/README.md
@@ -1,0 +1,63 @@
+# v0.4-alpha paired-task baseline corpus
+
+Fixtures for `eval/run_baselines.py` — the "baselines first" stage of the v0.4 learned-selector
+research (`docs/solution-design/model-research.md`). Everything here is **shadow-only**: it
+measures deterministic keep/drop selectors against downstream tasks; no model is involved and
+nothing reaches a served path.
+
+## Fixture schema
+
+```json
+{
+  "id": "log_qa_001",
+  "family": "log_qa | diff_review | json_schema | ...",
+  "tier": "A | B | C",
+  "source": "the raw captured text to compress",
+  "query": "the downstream question the compressed context must still answer",
+  "gold_answer": "substring that must survive for the task to be answerable",
+  "critical_atoms": ["ids/hashes/paths that must survive regardless of the selector"]
+}
+```
+
+- **`critical_atoms`** are force-kept by deterministic logic (units containing them are never
+  dropped), so 100% critical-atom survival is a structural guarantee — a hard gate in
+  model-research.md — not something a selector must learn. Put audit/CCR-critical ids, hashes,
+  and paths here.
+- **`gold_answer`** should live in a unit that is *not* a critical atom, so whether the task is
+  answerable genuinely depends on the selector + token budget. That is what differentiates the
+  baselines (and, later, a learned selector) instead of every policy trivially scoring 1.0.
+
+## Governance tiers (model-research.md §Prerequisites and Data)
+
+| Tier | Source | v0.4 use |
+| --- | --- | --- |
+| A | Project-owned synthetic traces / fault-injected builds | Training + evaluation |
+| B | MIT/Apache/BSD/CC0 public repos with file/revision manifests | Training + project-disjoint eval |
+| C | Explicitly opted-in, locally redacted user traces | Local shadow eval only; never centralized |
+
+Current corpus is **Tier A only** (synthetic, safe as the default CI corpus). Redact and
+secret-scan before persisting anything; reject rather than store secret-shaped content.
+
+## Running
+
+```bash
+python eval/run_baselines.py            # human summary curve
+python eval/run_baselines.py --json     # full JSON report (summary + per-row detail)
+python eval/run_baselines.py --gate     # assert invariants; non-zero exit on failure
+python eval/run_baselines.py --ratios 0.75,0.5,0.25
+```
+
+Install `tiktoken` (`pip install -e 'eval[exact]'`) for exact `o200k_base` ceilings; without it
+the harness falls back to the same byte/4 heuristic as `tokenfold-core` and labels the report
+`"backend": "heuristic"`.
+
+## Deferred to later v0.4-alpha work (not hidden)
+
+- Additional baselines as `SELECTORS` entries: RTK, RTK+tokenfold, deterministic-tokenfold (Rust
+  CLI subprocess), LLMLingua-style, and the unmodified Headroom Kompress-v2 achieved-token sweep.
+- Tier-B public-repo corpora with license/revision manifests; project-disjoint train/test splits
+  and near-dedup across splits.
+- Structural segmentation (diff hunks, JSON containers, AST/code blocks) — v0.4-alpha segments by
+  line.
+- Real paired build/test/debug/patch execution and an LLM judge for *diagnosing* failures (never
+  for satisfying a gate). The current scorer is a deterministic containment proxy.

--- a/eval/tasks/v04/diff_review_001.json
+++ b/eval/tasks/v04/diff_review_001.json
@@ -1,0 +1,10 @@
+{
+  "id": "diff_review_001",
+  "family": "diff_review",
+  "tier": "A",
+  "source": "diff --git a/src/auth/session.rs b/src/auth/session.rs\n--- a/src/auth/session.rs\n+++ b/src/auth/session.rs\n@@ -18,7 +18,7 @@ impl SessionStore {\n     pub fn validate_token(&self, token: &str) -> bool {\n-        self.tokens.contains(token)\n+        self.tokens.contains(token) && !self.revoked.contains(token)\n     }\n \n     pub fn revoke(&self, token: &str) {\n         self.revoked.insert(token.to_string());\n     }\n",
+  "query": "which function changed its return condition to also check revoked tokens?",
+  "gold_answer": "validate_token",
+  "critical_atoms": ["src/auth/session.rs"],
+  "notes": "The changed function signature line carries the answer and is query-relevant; the file path (audit-critical for change localization) sits on the +++/--- headers and is force-kept."
+}

--- a/eval/tasks/v04/json_schema_001.json
+++ b/eval/tasks/v04/json_schema_001.json
@@ -1,0 +1,10 @@
+{
+  "id": "json_schema_001",
+  "family": "json_schema",
+  "tier": "A",
+  "source": "{\n  \"tool\": \"search\",\n  \"request_id\": \"tc-7f3a2b1c\",\n  \"params\": {\n    \"query\": \"quarterly revenue\",\n    \"max_results\": 25,\n    \"timeout_ms\": 3000,\n    \"filters\": {\n      \"region\": \"emea\",\n      \"currency\": \"eur\"\n    }\n  },\n  \"retries\": 2\n}\n",
+  "query": "what is the configured max_results value?",
+  "gold_answer": "\"max_results\": 25",
+  "critical_atoms": ["tc-7f3a2b1c"],
+  "notes": "Line-segmented JSON (structural segmentation deferred). The answer line matches the query; request_id is force-kept. Gold answer is the full key:value so containment can't false-match a stray '25'."
+}

--- a/eval/tasks/v04/log_qa_001.json
+++ b/eval/tasks/v04/log_qa_001.json
@@ -1,0 +1,10 @@
+{
+  "id": "log_qa_001",
+  "family": "log_qa",
+  "tier": "A",
+  "source": "2026-07-01T10:00:00Z INFO service=auth starting up region=us-east-1\n2026-07-01T10:00:01Z INFO service=auth config loaded pool_size=32\n2026-07-01T10:00:02Z INFO service=auth healthcheck ok\n2026-07-01T10:00:03Z INFO service=auth request received route=/login user=alice\n2026-07-01T10:00:03Z DEBUG service=auth cache miss key=sess-alice\n2026-07-01T10:00:04Z INFO service=auth request received route=/login user=bob\n2026-07-01T10:00:05Z ERROR service=auth database connection timeout after 5000ms code=DB_TIMEOUT\n2026-07-01T10:00:06Z INFO service=auth retry scheduled req-id=req-9f3a\n2026-07-01T10:00:07Z INFO service=auth healthcheck ok\n2026-07-01T10:00:08Z INFO service=auth shutting down region=us-east-1\n",
+  "query": "what database error caused the request timeout?",
+  "gold_answer": "DB_TIMEOUT",
+  "critical_atoms": ["req-9f3a"],
+  "notes": "Answer (ERROR line) is NOT a critical atom and is an older line, so recency drops it at tight budgets while bm25 keeps it; the audit-critical req-id is on a separate line and is force-kept."
+}


### PR DESCRIPTION
## Summary

Kicks off **v0.4-alpha** (Phase 8, F-057): the "baselines first" stage of the learned-selector research in `docs/solution-design/model-research.md`. Adds a deterministic keep/drop **baseline benchmark harness** that runs paired downstream tasks at *exact provider-token ceilings* and reports an achieved-token / task-score curve.

**Shadow-only, no ML.** A learned selector (Granite 97M, v0.4-beta) will later plug into `SELECTORS` and be measured against exactly these baselines. Nothing here touches the shipped Rust/npm/Python runtime — targeting `develop` as the research integration branch.

## What's in it

- `eval/run_baselines.py` — stdlib-only harness (mirrors `run_fidelity.py`):
  - **Deterministic critical-atom forcing** makes 100% critical-atom survival a *structural* guarantee (a hard gate in model-research.md), independent of the selector. A selector only ranks the remaining units.
  - **Token-ceiling allocator** re-tokenizes the full candidate each step (spec-faithful, non-additive) so the ceiling holds on the assembled output.
  - **Baselines**: `keep_all` (raw upper bound), `forced_only` (floor), `recency`, `frequency`, `bm25`.
  - **Optional tiktoken** (`o200k_base`) for exact ceilings; byte/4 heuristic fallback otherwise, labeled in the report.
  - **Deterministic task scorer** (critical-atom survival + gold-answer containment) — an LLM judge is reserved for *diagnosing* failures, never for satisfying a gate.
- `eval/tasks/v04/` — 3 synthetic **Tier-A** fixtures (log-QA, diff-review, json-schema) with the gold answer in a *non-forced, query-relevant* unit so task success genuinely varies by selector, plus a README (fixture schema, governance tiers A/B/C, deferred work).

## Sample output

```
baseline      ratio   task   crit  achieved  over
keep_all       0.25    1.0    1.0       1.0     0
forced_only    0.25    0.0    1.0    0.1878     1
recency        0.25    0.0    1.0    0.2408     1
frequency      0.25 0.3333    1.0     0.246     1
bm25           0.25 0.3333    1.0     0.246     1
```

Critical-atom survival is 1.0 for every selector; `over` at 0.25 is legitimate (the forced safety floor exceeds a 25% budget for one fixture, which the gate explicitly allows).

## Testing

`python eval/run_baselines.py --gate` — 30 checks green: universal critical-atom survival, ceiling respected unless the forced floor exceeds budget, `keep_all` upper bound.

## Deferred (documented, not hidden)

RTK / RTK+tokenfold / deterministic-tokenfold-CLI / LLMLingua-style / Headroom Kompress-v2 baselines; Tier-B public-repo corpora + project-disjoint splits; structural (diff/JSON/AST) segmentation; real paired build/test execution + LLM-judge diagnosis.
