### PR TITLE
feat(v0.4-alpha): deterministic-tokenfold compressor baseline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 *.cdx.json
 .env
 .claude/*
+# Python bytecode caches (eval/ + python-tests harnesses)
+__pycache__/
+*.pyc

--- a/eval/run_baselines.py
+++ b/eval/run_baselines.py
@@ -26,7 +26,10 @@ from __future__ import annotations
 import argparse
 import json
 import math
+import os
 import re
+import shutil
+import subprocess
 import sys
 from pathlib import Path
 
@@ -152,6 +155,57 @@ SELECTORS = {
 }
 
 
+# --- whole-pipeline compressor baselines ------------------------------------------------------
+# Unlike SELECTORS (which rank atomic units and get the harness's deterministic critical-atom
+# forcing + hard ceiling), a COMPRESSOR runs an external best-effort pipeline over the whole
+# source. It is NOT unit-selection: it may miss the exact ceiling (best effort) and the harness
+# does not force critical atoms through it, so its critical-atom survival is *measured and
+# reported*, never assumed. `deterministic-tokenfold` is the primary baseline to beat.
+
+
+def _find_tokenfold() -> str | None:
+    """Locate the tokenfold CLI: TOKENFOLD_BIN, then a local target build, then PATH."""
+    env = os.environ.get("TOKENFOLD_BIN")
+    if env and Path(env).is_file():
+        return env
+    root = Path(__file__).resolve().parent.parent
+    exe = "tokenfold.exe" if os.name == "nt" else "tokenfold"
+    for sub in ("target/release", "target/debug"):
+        candidate = root / sub / exe
+        if candidate.is_file():
+            return str(candidate)
+    return shutil.which("tokenfold")
+
+
+_TOKENFOLD_BIN = _find_tokenfold()
+
+
+def compress_tokenfold(source: str, budget: int) -> str | None:
+    """Run `tokenfold compress --target-tokens <budget>` over `source` (auto-detected format),
+    returning the compressed payload, or None when the CLI is unavailable/errors. Best-effort:
+    tokenfold may return a payload above the budget when its lossless/evidence transforms cannot
+    reach the target — that is a measured property, not a harness failure."""
+    if not _TOKENFOLD_BIN:
+        return None
+    try:
+        proc = subprocess.run(
+            [_TOKENFOLD_BIN, "compress", "--quiet", "--target-tokens", str(budget)],
+            input=source.encode("utf-8"),
+            capture_output=True,
+            timeout=30,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if not proc.stdout:
+        return None
+    return proc.stdout.decode("utf-8", errors="replace")
+
+
+COMPRESSORS = {
+    "deterministic-tokenfold": compress_tokenfold,
+}
+
+
 # --- token-ceiling allocator ------------------------------------------------------------------
 
 
@@ -195,15 +249,24 @@ def allocate(
 # --- task scoring (deterministic proxy) -------------------------------------------------------
 
 
+def _ws_strip(text: str) -> str:
+    return re.sub(r"\s+", "", text)
+
+
 def score_task(kept_text: str, fixture: dict) -> dict:
     """Deterministic proxy for downstream task success: every critical atom present AND the gold
     answer span present in the retained context. Not an LLM judge (which model-research.md
-    reserves for diagnosing failures, never for satisfying a gate)."""
+    reserves for diagnosing failures, never for satisfying a gate).
+
+    Containment is whitespace-insensitive so a lossless reformat (e.g. a compressor minifying
+    `"max_results": 25` to `"max_results":25`) still counts as surviving. Selector baselines keep
+    original bytes, so this does not change their scores."""
+    hay = _ws_strip(kept_text)
     atoms = fixture.get("critical_atoms", [])
-    survived = sum(1 for a in atoms if a in kept_text)
+    survived = sum(1 for a in atoms if _ws_strip(a) in hay)
     atom_survival = survived / len(atoms) if atoms else 1.0
     gold = fixture.get("gold_answer")
-    answer_present = 1.0 if (not gold or gold in kept_text) else 0.0
+    answer_present = 1.0 if (not gold or _ws_strip(gold) in hay) else 0.0
     success = 1.0 if atom_survival == 1.0 and answer_present == 1.0 else 0.0
     return {
         "task_success": success,
@@ -244,24 +307,57 @@ def run_one(fixture: dict, baseline: str, target_ratio: float) -> dict:
     return result
 
 
+def run_one_compressor(fixture: dict, name: str, target_ratio: float) -> dict:
+    source = fixture["source"]
+    raw_tokens = count_tokens(source)
+    budget = round(raw_tokens * target_ratio)
+    compressed = COMPRESSORS[name](source, budget)
+    base = {
+        "baseline": name,
+        "fixture": fixture["id"],
+        "family": fixture.get("family"),
+        "target_ratio": target_ratio,
+        "kind": "compressor",
+    }
+    if compressed is None:
+        base["available"] = False
+        return base
+    achieved = count_tokens(compressed)
+    base.update(
+        {
+            "available": True,
+            "raw_tokens": raw_tokens,
+            "budget_tokens": budget,
+            "achieved_tokens": achieved,
+            "achieved_ratio": round(achieved / raw_tokens, 4) if raw_tokens else 0.0,
+            # Best effort: tokenfold may exceed the budget when lossless transforms can't reach
+            # it. Informational, not a failure.
+            "over_budget": achieved > budget,
+        }
+    )
+    base.update(score_task(compressed, fixture))
+    return base
+
+
 def _mean(xs: list[float]) -> float:
     return round(sum(xs) / len(xs), 4) if xs else 0.0
 
 
 def build_report(fixtures: list[dict], ratios: list[float]) -> dict:
-    rows = [
-        run_one(fx, name, r)
-        for name in SELECTORS
-        for r in ratios
-        for fx in fixtures
+    selector_rows = [
+        run_one(fx, name, r) for name in SELECTORS for r in ratios for fx in fixtures
+    ]
+    compressor_rows = [
+        run_one_compressor(fx, name, r) for name in COMPRESSORS for r in ratios for fx in fixtures
     ]
     summary = []
     for name in SELECTORS:
         for r in ratios:
-            group = [x for x in rows if x["baseline"] == name and x["target_ratio"] == r]
+            group = [x for x in selector_rows if x["baseline"] == name and x["target_ratio"] == r]
             summary.append(
                 {
                     "baseline": name,
+                    "kind": "selector",
                     "target_ratio": r,
                     "mean_task_success": _mean([x["task_success"] for x in group]),
                     "mean_critical_atom_survival": _mean(
@@ -271,14 +367,35 @@ def build_report(fixtures: list[dict], ratios: list[float]) -> dict:
                     "over_budget_count": sum(1 for x in group if x["over_budget"]),
                 }
             )
+    for name in COMPRESSORS:
+        for r in ratios:
+            group = [x for x in compressor_rows if x["baseline"] == name and x["target_ratio"] == r]
+            avail = [x for x in group if x.get("available")]
+            summary.append(
+                {
+                    "baseline": name,
+                    "kind": "compressor",
+                    "target_ratio": r,
+                    "available": len(avail),
+                    "of": len(group),
+                    "mean_task_success": _mean([x["task_success"] for x in avail]),
+                    "mean_critical_atom_survival": _mean(
+                        [x["critical_atom_survival"] for x in avail]
+                    ),
+                    "mean_achieved_ratio": _mean([x["achieved_ratio"] for x in avail]),
+                    "over_budget_count": sum(1 for x in avail if x["over_budget"]),
+                }
+            )
     return {
         "harness": "v0.4-alpha-baselines",
         "tokenizer": TOKENIZER,
         "fixture_count": len(fixtures),
-        "baselines": list(SELECTORS),
+        "selectors": list(SELECTORS),
+        "compressors": list(COMPRESSORS),
+        "tokenfold_available": _TOKENFOLD_BIN is not None,
         "ratios": ratios,
         "summary": summary,
-        "rows": rows,
+        "rows": selector_rows + compressor_rows,
     }
 
 
@@ -324,6 +441,8 @@ def run_gate(fixtures: list[dict], ratios: list[float]) -> int:
         "gate": "pass" if not failures else "fail",
         "tokenizer": TOKENIZER,
         "checked": len(fixtures) * len(ratios) * len(SELECTORS),
+        # Compressor baselines are best-effort (measured, not gated); report availability only.
+        "tokenfold_available": _TOKENFOLD_BIN is not None,
         "failures": failures,
     }
     print(json.dumps(artifact, indent=2))
@@ -331,12 +450,19 @@ def run_gate(fixtures: list[dict], ratios: list[float]) -> int:
 
 
 def _print_summary(report: dict) -> None:
-    print(f"# v0.4-alpha baselines  (tokenizer: {report['tokenizer']['backend']})")
+    tf = "available" if report["tokenfold_available"] else "MISSING (skipped)"
+    print(
+        f"# v0.4-alpha baselines  (tokenizer: {report['tokenizer']['backend']}, "
+        f"deterministic-tokenfold: {tf})"
+    )
     print(f"# {report['fixture_count']} fixtures  ratios={report['ratios']}\n")
-    print(f"{'baseline':<13}{'ratio':>6}{'task':>7}{'crit':>7}{'achieved':>10}{'over':>6}")
+    print(f"{'baseline':<24}{'ratio':>6}{'task':>7}{'crit':>7}{'achieved':>10}{'over':>6}")
     for s in report["summary"]:
+        if s["kind"] == "compressor" and s.get("available", 0) == 0:
+            print(f"{s['baseline']:<24}{s['target_ratio']:>6}{'n/a':>7}{'n/a':>7}{'n/a':>10}{'-':>6}")
+            continue
         print(
-            f"{s['baseline']:<13}{s['target_ratio']:>6}{s['mean_task_success']:>7}"
+            f"{s['baseline']:<24}{s['target_ratio']:>6}{s['mean_task_success']:>7}"
             f"{s['mean_critical_atom_survival']:>7}{s['mean_achieved_ratio']:>10}"
             f"{s['over_budget_count']:>6}"
         )

--- a/eval/tasks/v04/README.md
+++ b/eval/tasks/v04/README.md
@@ -51,10 +51,25 @@ Install `tiktoken` (`pip install -e 'eval[exact]'`) for exact `o200k_base` ceili
 the harness falls back to the same byte/4 heuristic as `tokenfold-core` and labels the report
 `"backend": "heuristic"`.
 
+## Baseline kinds: selectors vs. compressors
+
+- **Selectors** (`keep_all`, `forced_only`, `recency`, `frequency`, `bm25`) rank atomic units.
+  The harness force-keeps critical-atom units and enforces the exact token ceiling on them, so
+  100% critical-atom survival and the ceiling are guarantees.
+- **Compressors** (`deterministic-tokenfold`) run a whole-pipeline best-effort compressor over
+  the source — the harness does *not* force atoms through them, so their critical-atom survival
+  and achieved ratio are **measured, not asserted**. `deterministic-tokenfold` shells out to the
+  real Rust CLI, discovered via `TOKENFOLD_BIN`, then a local `target/{release,debug}` build,
+  then `PATH`; when it isn't found the baseline is cleanly skipped (`n/a`) and the report/gate
+  say so, so this harness still runs in a build-less CI. It is the primary **baseline to beat**:
+  it is lossless/evidence-safe (task + critical survival ≈ 1.0) but often cannot reach aggressive
+  budgets on low-repetition inputs — the exact gap a learned selector must close.
+
 ## Deferred to later v0.4-alpha work (not hidden)
 
-- Additional baselines as `SELECTORS` entries: RTK, RTK+tokenfold, deterministic-tokenfold (Rust
-  CLI subprocess), LLMLingua-style, and the unmodified Headroom Kompress-v2 achieved-token sweep.
+- Remaining baselines: RTK and RTK+tokenfold (external tool), an LLMLingua-style selector, and
+  the unmodified Headroom Kompress-v2 achieved-token sweep. (`deterministic-tokenfold` is now
+  implemented as a compressor baseline — see above.)
 - Tier-B public-repo corpora with license/revision manifests; project-disjoint train/test splits
   and near-dedup across splits.
 - Structural segmentation (diff hunks, JSON containers, AST/code blocks) — v0.4-alpha segments by


### PR DESCRIPTION
## Summary

Adds the **`deterministic-tokenfold` baseline** to the v0.4-alpha harness (F-057) — the primary "baseline to beat" from `model-research.md`. It runs the real tokenfold Rust CLI as a whole-pipeline compressor so the learned selector (v0.4-beta) can be measured against the deterministic pipeline it must improve on.

## What's in it

- **New compressor-kind baseline** (distinct from the unit-ranking selectors): `deterministic-tokenfold` shells out to `tokenfold compress --target-tokens <budget>`. Because it's a whole-pipeline best-effort compressor, the harness does **not** force critical atoms through it or enforce the exact ceiling — its critical-atom survival and achieved ratio are **measured, not asserted** (honest: a selector gets guarantees the CLI can't).
- **Binary discovery + graceful skip**: `TOKENFOLD_BIN` → local `target/{release,debug}` → `PATH`; when absent the baseline is cleanly skipped (`n/a`) and the report/gate say so, so the harness still runs in a build-less CI. Verified both paths.
- **Whitespace-insensitive task containment** so a lossless reformat (e.g. JSON minify collapsing `"max_results": 25` → `"max_results":25`) still counts as surviving. Selector scores are unchanged.
- `.gitignore` now covers Python `__pycache__`.

## The finding

```
baseline                 ratio   task   crit  achieved  over
keep_all                  0.25    1.0    1.0       1.0     0
bm25                      0.25 0.3333    1.0     0.246     1
deterministic-tokenfold   0.25    1.0    1.0    0.8727     3
```

`deterministic-tokenfold` is lossless/evidence-safe (task + critical survival ≈ 1.0) but only reaches ~0.87 and **cannot hit the 0.5/0.25 budgets** on these low-repetition inputs (`over_budget`), while the aggressive selectors hit the budget but drop task success. That gap — safe-but-limited-ratio vs. aggressive-but-lossy — is precisely what a learned selector must close.

## Testing

`python eval/run_baselines.py --gate` → pass (30 selector invariant checks; `tokenfold_available` reported). Verified the graceful-skip path (binary absent → `n/a`, gate still passes).

## Still deferred

RTK / RTK+tokenfold (external tool), LLMLingua-style selector, Headroom Kompress-v2 achieved-token sweep; Tier-B public-repo corpora + project-disjoint splits; structural segmentation; real paired build/test execution.
