### PR TITLE
chore: protect main, document trunk-based branch model

### DIFF
--- a/.github/rulesets/main-protection.json
+++ b/.github/rulesets/main-protection.json
@@ -1,0 +1,42 @@
+{
+  "name": "main",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["~DEFAULT_BRANCH"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    { "type": "deletion" },
+    { "type": "non_fast_forward" },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": false,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": false,
+        "allowed_merge_methods": ["squash", "merge"]
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": false,
+        "required_status_checks": [
+          { "context": "lint" },
+          { "context": "test" },
+          { "context": "node-api (Node 22)" },
+          { "context": "node-api (Node 24)" },
+          { "context": "coverage" },
+          { "context": "golden-cross-platform (macos-15)" },
+          { "context": "golden-cross-platform (macos-15-intel)" },
+          { "context": "golden-cross-platform (ubuntu-latest)" }
+        ]
+      }
+    }
+  ]
+}

--- a/.github/rulesets/release-tags.json
+++ b/.github/rulesets/release-tags.json
@@ -1,0 +1,15 @@
+{
+  "name": "release tags",
+  "target": "tag",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["refs/tags/v*"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    { "type": "deletion" },
+    { "type": "non_fast_forward" }
+  ]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main]
   pull_request:
-    branches: [main, develop]
+    branches: [main]
 
 env:
   CARGO_TERM_COLOR: always

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,13 @@ python eval/run_fidelity.py --gate --profile smoke-first-consumer
 
 If a check cannot run in the current environment, report exactly which check was skipped and why.
 
+## Branches and pull requests
+
+- Never push to `main`. It is protected: every change lands through a pull request with green CI, including release-preparation commits. See [CONTRIBUTING.md](CONTRIBUTING.md).
+- Branch from current `main` using `feat/`, `fix/`, `chore/`, `docs/`, or `release/` prefixes, and keep the branch short-lived.
+- `main` is the only long-lived branch. Do not create environment branches (`develop`, `preprod`, `production`); releases are selected by `vX.Y.Z` tags, not by branches.
+- Released tags are immutable. Never delete or force-move a `v*` tag.
+
 ## Documentation and releases
 
 - Update user-facing documentation when commands, configuration, output, or supported integrations change.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,98 @@
+# Contributing
+
+## Branch model
+
+`main` is the only long-lived branch. It is protected: no direct pushes, no
+force-pushes, no deletion. Every change lands through a pull request with green
+CI. Releases are annotated `vX.Y.Z` tags on `main` — the tag, not a branch, is
+what selects a version for crates.io, PyPI, npm, and GitHub Releases.
+
+There is no `develop`, `preprod`, or `production` branch. Those model a
+continuously-deployed service where a branch's HEAD *is* an environment.
+Tokenfold publishes versioned artifacts to package registries, so the release
+selector is the tag and an extra long-lived branch would gate nothing.
+
+```text
+main  ─────●─────●─────●─────●─────  protected, always releasable
+           ↑     ↑           ↑
+        feat/  fix/       tag v0.4.1 → release.yml → publish-packages.yml
+```
+
+Work branches are short-lived and named `feat/…`, `fix/…`, `chore/…`,
+`docs/…`, or `release/…`. Delete them after merge.
+
+## Making a change
+
+```sh
+git switch main && git pull
+git switch -c feat/short-description
+# ... commit ...
+git push -u origin feat/short-description
+gh pr create --fill
+gh pr merge --squash --delete-branch    # once CI is green
+```
+
+Run the checks in [AGENTS.md](AGENTS.md) before opening the PR; CI runs the
+same ones.
+
+## Cutting a release
+
+Release commits go through a PR like everything else.
+
+```sh
+git switch main && git pull
+git switch -c release/v0.4.1
+# bump: Cargo.toml [workspace.package], inter-crate dep pins, cargo update -w,
+#       packages/tokenfold/package.json + optionalDependencies,
+#       npm install --package-lock-only, test version assertions, CHANGELOG.md
+git push -u origin release/v0.4.1
+gh pr create --fill && gh pr merge --squash --delete-branch
+
+git switch main && git pull
+git tag -a v0.4.1 -m "v0.4.1" && git push origin v0.4.1   # fires release.yml
+# wait for the GitHub Release to exist, then:
+gh workflow run publish-packages.yml -f version=0.4.1
+```
+
+Release tags are protected against deletion and force-moves: a published tag is
+immutable, because `publish-packages.yml` builds registry artifacts from the
+release it produced.
+
+## Repository rulesets
+
+The protection above is stored as code in [.github/rulesets/](.github/rulesets/)
+so it can be reviewed and re-applied. GitHub has no mechanism to sync these
+automatically — apply them once, and re-apply after editing:
+
+```sh
+gh api --method POST repos/snchimata/tokenfold/rulesets \
+  --input .github/rulesets/main-protection.json
+gh api --method POST repos/snchimata/tokenfold/rulesets \
+  --input .github/rulesets/release-tags.json
+
+gh api repos/snchimata/tokenfold/rulesets --jq '.[] | "\(.id)\t\(.name)\t\(.enforcement)"'
+# to update an existing one: --method PUT .../rulesets/<id>
+```
+
+Note: repository admins do **not** automatically bypass rulesets the way they
+could opt out of classic branch protection. If you need an escape hatch, add a
+`bypass_actors` entry to `main-protection.json` rather than deleting the rule.
+
+## Required status checks
+
+`main-protection.json` requires: `lint`, `test`, `node-api (Node 22)`,
+`node-api (Node 24)`, `coverage`, and the three `golden-cross-platform` matrix
+legs.
+
+Three CI jobs are deliberately **not** required, because they cannot gate a PR:
+
+| Job | Why it is not required |
+|---|---|
+| `bench-smoke` | `if: github.event_name == 'push'` — never runs on a PR, so requiring it would block every PR forever |
+| `security` | `continue-on-error` on PRs — always reports success there |
+| `fidelity-smoke` | `continue-on-error` on PRs — always reports success there |
+
+The last two follow the existing "advisory on PR, blocking on push to `main`"
+policy in [ci.yml](.github/workflows/ci.yml). Now that everything reaches `main`
+through a merge, their blocking tier fires *after* the merge rather than
+preventing it. Removing the `continue-on-error` conditions would close that gap.


### PR DESCRIPTION
Enforces "no direct push to main" and writes down the branch model.

## What changed

- `.github/rulesets/main-protection.json` — PR required (0 approvals, squash/merge), 8 required status checks, blocks deletion and force-push. Already applied as ruleset `20996245`.
- `.github/rulesets/release-tags.json` — `refs/tags/v*` immutable. Already applied as ruleset `20996247`.
- `CONTRIBUTING.md` — branch model, change flow, release-via-PR flow, ruleset apply commands.
- `AGENTS.md` — "Branches and pull requests" section.
- `ci.yml` — dropped the deleted `develop` branch from both triggers.

## Branch model

`main` is the only long-lived branch; releases are selected by `vX.Y.Z` tags, not by branches. No `develop`/`preprod`/`production` — those model a continuously-deployed service, whereas this repo publishes versioned artifacts to crates.io, PyPI, npm, and GitHub Releases, where the tag is the release selector. The stale `develop` branch (0 ahead of main, 18 behind) has been deleted.

This supersedes the previous convention of pushing release commits directly to `main`.

## Required status checks

Required: `lint`, `test`, `node-api (Node 22)`, `node-api (Node 24)`, `coverage`, and the three `golden-cross-platform` matrix legs.

Three jobs are deliberately excluded because they cannot gate a PR:

| Job | Why |
|---|---|
| `bench-smoke` | `if: github.event_name == 'push'` — never runs on a PR, so requiring it would block every PR permanently |
| `security` | `continue-on-error` on PRs — always reports success there |
| `fidelity-smoke` | `continue-on-error` on PRs — always reports success there |

Known gap, not addressed here: the existing "advisory on PR, blocking on push to `main`" policy now fires only *after* a merge, since nothing else pushes to `main`. Closing it means dropping those `continue-on-error` conditions.