### PR TITLE
feat(bindings): expose opt-in lossy JSON pruning from Python and TypeScript

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ venv/
 
 # Scratch data.
 /data/
+
+# Local scratch workspace for running examples (venv + copied notebook).
+/tokenfold_run/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## [Unreleased]
+
+- **Python: opt-in lossy JSON pruning is now reachable from the binding**, previously
+  CLI-only. `CompressionPolicy` gained `lossy`, `lossy_ratio`, `lossy_preserve`, and
+  `retrieval_store_path`; `compress()`/`inspect()` accept `lossy`/`lossy_ratio`/
+  `lossy_preserve` directly, mirroring the CLI's `--lossy`/`--lossy-ratio`/
+  `--lossy-preserve`. New `tokenfold.retrieve(hash, *, namespace=, backend=,
+  retrieval_store_path=, policy=)` restores a dropped item's original bytes
+  (`tokenfold_core::retrieval_store::RetrievalStore`), raising the new `RetrievalError`
+  for a missing or expired hash. New `LossyPath` enum (`HEURISTIC`, the only Phase 1
+  path). Same fail-closed guarantees as the CLI: `CompressionPolicy.validate()` still
+  refuses `lossy` without a durable `filesystem` retrieval backend and a TTL floor.
+  `lossy` only ever has an effect on generic JSON (`format=JSON`); every other format
+  silently no-ops it, exactly as the CLI does.
+
+- **TypeScript: opt-in lossy JSON pruning is now reachable from the package**, previously
+  CLI-only. `CompressionOptions` gained `lossy`, `lossyRatio`, and `lossyPreserve`, mirroring
+  the CLI's `--lossy`/`--lossy-ratio`/`--lossy-preserve`; `inspect()` with `lossy` set routes
+  to `compress --dry-run`, the CLI's own lossy preview, since the `inspect` subcommand has no
+  lossy flags of its own. New `retrieve(reference, { namespace, configPath, signal })` restores
+  a dropped item's original bytes via `tokenfold retrieve`, accepting a raw hash or a
+  `[tokenfold:retrieve hash=... namespace=...]` marker (whose embedded namespace wins when
+  `namespace` is omitted), and throwing `TokenFoldProcessError` (`code: "tokenfold_exit"`) for a
+  missing hash, an expired one, or a malformed reference. New `LossyPath` type. `lossyRatio` and
+  `lossyPreserve` are forwarded even without `lossy`, so the CLI's own `requires = "lossy"`
+  rejects the combination rather than the option being silently dropped.
+- Docs: the "lossy pruning is CLI-only; Python and TypeScript remain lossless" note in
+  `README.md` and the `examples/` headers is no longer true and has been corrected.
+
 ## [0.4.0] - 2026-08-15
 
 Minor, not a patch: this release changes the public Rust API (see "Breaking"

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ print(f"saved {result.report.saved_tokens} tokens ({result.saved_pct():.1f}%)")
 `tokenfold doctor` verifies it. Trusted filters for Git, build, and test output
 are available through `tokenfold filters list`.
 
-Runnable examples, one per surface:
+Runnable examples, one per surface, all under [`examples/`](examples):
 
 ```bash
 python examples/quickstart.py      # Python: compress messages, request bodies, JSON data
@@ -130,6 +130,9 @@ node examples/quickstart.mjs       # TypeScript/Node: compress, inspect, read th
 cargo run -p tokenfold-core --example quickstart   # Rust: the embedded core API
 python examples/lossy_pruning.py   # CLI: opt-in recoverable pruning, end to end
 ```
+
+[`examples/quickstart.ipynb`](examples/quickstart.ipynb) is the notebook form of the
+Python quickstart, one operation per cell.
 
 ## Recoverable lossy pruning
 

--- a/README.md
+++ b/README.md
@@ -122,11 +122,13 @@ print(f"saved {result.report.saved_tokens} tokens ({result.saved_pct():.1f}%)")
 `tokenfold doctor` verifies it. Trusted filters for Git, build, and test output
 are available through `tokenfold filters list`.
 
-Runnable examples:
+Runnable examples, one per surface:
 
 ```bash
-python examples/quickstart.py
-python examples/lossy_pruning.py
+python examples/quickstart.py      # Python: compress messages, request bodies, JSON data
+node examples/quickstart.mjs       # TypeScript/Node: compress, inspect, read the receipt
+cargo run -p tokenfold-core --example quickstart   # Rust: the embedded core API
+python examples/lossy_pruning.py   # CLI: opt-in recoverable pruning, end to end
 ```
 
 ## Recoverable lossy pruning

--- a/README.md
+++ b/README.md
@@ -187,6 +187,27 @@ tokenfold compress examples/incident_feed.json --format json \
   --lossy heuristic --lossy-ratio 0.35 --dry-run
 ```
 
+The same flags, and the same fail-closed contract, from Python and TypeScript:
+
+```python
+from tokenfold import CompressionPolicy, InputFormat, LossyPath, compress, retrieve
+
+policy = CompressionPolicy(lossy=LossyPath.HEURISTIC, lossy_ratio=0.35)
+result = compress(feed_bytes, format=InputFormat.JSON, policy=policy)
+original = retrieve(marker["$tf_ref"]["hash"])   # any dropped row, verbatim
+```
+
+```ts
+import { compress, retrieve } from "tokenfold";
+
+const { payload, report } = await compress(feed, {
+  format: "json",
+  lossy: "heuristic",
+  lossyRatio: 0.35,
+});
+const original = await retrieve(hash); // any dropped row, verbatim
+```
+
 <details>
 <summary><strong>Current Phase 1 constraints</strong></summary>
 
@@ -195,9 +216,8 @@ already contain retrieval markers. A filesystem failure after partial writes
 may also leave unreferenced entries until their configured TTL expires. Both
 require location-based transactional materialization before promotion.
 
-Lossy pruning is CLI-only today; Python and TypeScript remain lossless. Preview
-is a projection rather than a filesystem transaction, so a real run may keep
-more rows if storage becomes unavailable.
+Preview is a projection rather than a filesystem transaction, so a real run may
+keep more rows if storage becomes unavailable.
 
 </details>
 

--- a/crates/tokenfold-core/Cargo.toml
+++ b/crates/tokenfold-core/Cargo.toml
@@ -28,3 +28,10 @@ tiktoken = ["dep:tiktoken-rs"]
 [[bench]]
 name = "compression_bench"
 harness = false
+
+# The example lives in the repo-root examples/ folder, beside the Python, Node, and
+# CLI ones, so all four surfaces stay in one place. Out-of-root targets are not
+# packaged, which is the point: the example reads fixtures this crate does not ship.
+[[example]]
+name = "quickstart"
+path = "../../examples/quickstart.rs"

--- a/crates/tokenfold-py/src/lib.rs
+++ b/crates/tokenfold-py/src/lib.rs
@@ -16,6 +16,8 @@
 #![allow(unsafe_op_in_unsafe_fn, unexpected_cfgs)]
 #![allow(clippy::useless_conversion)]
 
+use std::path::PathBuf;
+
 use pyo3::IntoPyObjectExt;
 use pyo3::create_exception;
 use pyo3::exceptions::{PyException, PyOSError};
@@ -23,10 +25,11 @@ use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyDict, PyList};
 
 use tokenfold_core::report::TransformStatus;
+use tokenfold_core::retrieval_store::{RetrievalOutcome, RetrievalStore};
 use tokenfold_core::{
     CompressionInput, CompressionMode as CoreMode, CompressionOutput as CoreOutput,
-    CompressionPolicy as CorePolicy, InputFormat as CoreFormat, Status as CoreStatus,
-    TokenFoldError as CoreError,
+    CompressionPolicy as CorePolicy, InputFormat as CoreFormat, LossyPath as CoreLossyPath,
+    Status as CoreStatus, TokenFoldError as CoreError,
 };
 
 // ---------------------------------------------------------------------------------------
@@ -41,6 +44,11 @@ create_exception!(tokenfold, SafetyError, TokenFoldError);
 create_exception!(tokenfold, EstimatorError, TokenFoldError);
 create_exception!(tokenfold, ConfigError, TokenFoldError);
 create_exception!(tokenfold, InternalError, TokenFoldError);
+// Raised by retrieve() when a hash is not found in the given namespace, or was found but its
+// TTL has elapsed -- the two non-`Found` arms of `retrieval_store::RetrievalOutcome`. A plain
+// `//` comment, not `///`: `create_exception!` doesn't attach outer doc comments to the item
+// it generates, so a doc comment here would just be a `-D warnings`-tripping dead comment.
+create_exception!(tokenfold, RetrievalError, TokenFoldError);
 
 /// Maps `tokenfold_core::TokenFoldError` to the Python exception hierarchy above. `Io`
 /// maps to the builtin `OSError`, not `InternalError`: an I/O failure is the caller's
@@ -176,6 +184,42 @@ impl From<CoreStatus> for PyStatus {
     }
 }
 
+/// Selection backend for opt-in lossy JSON array-item pruning -- see `CompressionPolicy.lossy`.
+/// `HEURISTIC` is the only Phase 1 implementation; deliberately a single-variant enum rather
+/// than a bare `bool`, matching `tokenfold_core::budget::LossyPath`'s own rationale (this
+/// names an algorithm, not a toggle) and the CLI's `--lossy heuristic` shape.
+#[pyclass(name = "LossyPath", eq, from_py_object)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PyLossyPath {
+    #[pyo3(name = "HEURISTIC")]
+    Heuristic,
+}
+
+impl From<PyLossyPath> for CoreLossyPath {
+    fn from(p: PyLossyPath) -> Self {
+        match p {
+            PyLossyPath::Heuristic => CoreLossyPath::Heuristic,
+        }
+    }
+}
+
+impl From<CoreLossyPath> for PyLossyPath {
+    fn from(p: CoreLossyPath) -> Self {
+        match p {
+            CoreLossyPath::Heuristic => PyLossyPath::Heuristic,
+        }
+    }
+}
+
+fn parse_lossy_str(s: &str) -> PyResult<CoreLossyPath> {
+    match s.to_ascii_uppercase().as_str() {
+        "HEURISTIC" => Ok(CoreLossyPath::Heuristic),
+        other => Err(ConfigError::new_err(format!(
+            "unknown LossyPath: {other:?}"
+        ))),
+    }
+}
+
 /// Accepts either the `CompressionMode` enum or a (case-insensitive) string, matching the
 /// public `mode: CompressionMode | str` signature.
 #[derive(FromPyObject)]
@@ -206,6 +250,23 @@ impl FormatArg {
         match self {
             FormatArg::Enum(f) => Ok(f.into()),
             FormatArg::Str(s) => parse_format_str(&s),
+        }
+    }
+}
+
+/// Accepts either the `LossyPath` enum or a (case-insensitive) string, matching the public
+/// `lossy: LossyPath | str | None` signature.
+#[derive(FromPyObject)]
+enum LossyArg {
+    Enum(PyLossyPath),
+    Str(String),
+}
+
+impl LossyArg {
+    fn resolve(self) -> PyResult<CoreLossyPath> {
+        match self {
+            LossyArg::Enum(p) => Ok(p.into()),
+            LossyArg::Str(s) => parse_lossy_str(&s),
         }
     }
 }
@@ -252,6 +313,10 @@ impl PyCompressionPolicy {
         retrieval_namespace=None,
         retrieval_ttl_seconds=None,
         retrieval_backend=None,
+        retrieval_store_path=None,
+        lossy=None,
+        lossy_ratio=None,
+        lossy_preserve=None,
     ))]
     #[allow(clippy::too_many_arguments)]
     fn new(
@@ -267,6 +332,10 @@ impl PyCompressionPolicy {
         retrieval_namespace: Option<String>,
         retrieval_ttl_seconds: Option<u64>,
         retrieval_backend: Option<String>,
+        retrieval_store_path: Option<PathBuf>,
+        lossy: Option<LossyArg>,
+        lossy_ratio: Option<f64>,
+        lossy_preserve: Option<Vec<String>>,
     ) -> PyResult<Self> {
         let mut builder = CorePolicy::builder();
         if let Some(t) = target_tokens {
@@ -297,6 +366,16 @@ impl PyCompressionPolicy {
         if let Some(backend) = retrieval_backend {
             builder = builder.retrieval_backend(backend);
         }
+        builder = builder.retrieval_store_path(retrieval_store_path);
+        if let Some(l) = lossy {
+            builder = builder.lossy(l.resolve()?);
+        }
+        if let Some(r) = lossy_ratio {
+            builder = builder.lossy_ratio(r);
+        }
+        for path in lossy_preserve.unwrap_or_default() {
+            builder = builder.lossy_preserve(path);
+        }
         Ok(Self(builder.build().map_err(map_err)?))
     }
 
@@ -318,6 +397,32 @@ impl PyCompressionPolicy {
     #[getter]
     fn store_originals(&self) -> bool {
         self.0.store_originals
+    }
+
+    // Returned as `str`, not `PathBuf`: the storage type is `Option<PathBuf>`, but the
+    // return-direction Python conversion for `PathBuf` is a needless risk to take on for a
+    // getter when `str` is unambiguous and just as usable from the caller's side.
+    #[getter]
+    fn retrieval_store_path(&self) -> Option<String> {
+        self.0
+            .retrieval_store_path
+            .as_ref()
+            .map(|p| p.display().to_string())
+    }
+
+    #[getter]
+    fn lossy(&self) -> Option<PyLossyPath> {
+        self.0.lossy.map(PyLossyPath::from)
+    }
+
+    #[getter]
+    fn lossy_ratio(&self) -> f64 {
+        self.0.lossy_ratio
+    }
+
+    #[getter]
+    fn lossy_preserve(&self) -> Vec<String> {
+        self.0.lossy_preserve.clone()
     }
 }
 
@@ -520,11 +625,15 @@ fn py_to_json(value: &Bound<'_, PyAny>) -> PyResult<serde_json::Value> {
 // when a flag and a config file disagree.
 // ---------------------------------------------------------------------------------------
 
+#[allow(clippy::too_many_arguments)]
 fn effective_policy(
     policy: Option<&PyCompressionPolicy>,
     mode: Option<ModeArg>,
     target_tokens: Option<usize>,
     disable: Option<Vec<String>>,
+    lossy: Option<LossyArg>,
+    lossy_ratio: Option<f64>,
+    lossy_preserve: Option<Vec<String>>,
     preview: bool,
 ) -> PyResult<CorePolicy> {
     let base = policy.map(|p| &p.0);
@@ -545,6 +654,23 @@ fn effective_policy(
         disable.unwrap_or_else(|| base.map(|p| p.disabled.clone()).unwrap_or_default());
     for id in resolved_disable {
         builder = builder.disable(id);
+    }
+
+    let resolved_lossy = match lossy {
+        Some(l) => Some(l.resolve()?),
+        None => base.and_then(|p| p.lossy),
+    };
+    if let Some(l) = resolved_lossy {
+        builder = builder.lossy(l);
+    }
+    let resolved_lossy_ratio = lossy_ratio.or_else(|| base.map(|p| p.lossy_ratio));
+    if let Some(r) = resolved_lossy_ratio {
+        builder = builder.lossy_ratio(r);
+    }
+    let resolved_lossy_preserve = lossy_preserve
+        .unwrap_or_else(|| base.map(|p| p.lossy_preserve.clone()).unwrap_or_default());
+    for path in resolved_lossy_preserve {
+        builder = builder.lossy_preserve(path);
     }
 
     if let Some(p) = base {
@@ -598,6 +724,9 @@ fn run_compress(
     mode: Option<ModeArg>,
     target_tokens: Option<usize>,
     disable: Option<Vec<String>>,
+    lossy: Option<LossyArg>,
+    lossy_ratio: Option<f64>,
+    lossy_preserve: Option<Vec<String>>,
     allow_heuristic_budget: bool,
     dry_run: bool,
 ) -> PyResult<PyCompressionResult> {
@@ -609,7 +738,16 @@ fn run_compress(
     // retrieval store. `preview` is the switch that actually stops the write, in core, before it
     // happens; the payload substitution below stays as the presentation half of the same
     // contract.
-    let resolved_policy = effective_policy(policy, mode, target_tokens, disable, dry_run)?;
+    let resolved_policy = effective_policy(
+        policy,
+        mode,
+        target_tokens,
+        disable,
+        lossy,
+        lossy_ratio,
+        lossy_preserve,
+        dry_run,
+    )?;
     let input = CompressionInput {
         format,
         bytes: bytes.clone(),
@@ -633,7 +771,7 @@ fn run_compress(
 // ---------------------------------------------------------------------------------------
 
 #[pyfunction]
-#[pyo3(signature = (payload, *, policy=None, format=None, mode=None, target_tokens=None, disable=None, allow_heuristic_budget=false))]
+#[pyo3(signature = (payload, *, policy=None, format=None, mode=None, target_tokens=None, disable=None, allow_heuristic_budget=false, lossy=None, lossy_ratio=None, lossy_preserve=None))]
 #[allow(clippy::too_many_arguments)]
 fn compress(
     py: Python<'_>,
@@ -644,6 +782,14 @@ fn compress(
     target_tokens: Option<usize>,
     disable: Option<Vec<String>>,
     allow_heuristic_budget: bool,
+    // Opt-in LOSSY JSON array-item pruning, mirroring the CLI's `--lossy`/`--lossy-ratio`/
+    // `--lossy-preserve` flags. Only ever has an effect when `format` resolves to `JSON` --
+    // core silently no-ops it (`NotApplicableToFormat`) on every other format, exactly as the
+    // CLI does. See `CompressionPolicy.lossy` for the full contract (recoverable via
+    // `retrieve()`, requires a durable `filesystem` retrieval backend).
+    lossy: Option<LossyArg>,
+    lossy_ratio: Option<f64>,
+    lossy_preserve: Option<Vec<String>>,
 ) -> PyResult<PyCompressionResult> {
     let resolved_format = format
         .map(FormatArg::resolve)
@@ -657,13 +803,17 @@ fn compress(
         mode,
         target_tokens,
         disable,
+        lossy,
+        lossy_ratio,
+        lossy_preserve,
         allow_heuristic_budget,
         false,
     )
 }
 
 #[pyfunction]
-#[pyo3(signature = (payload, *, policy=None, format=None, mode=None, target_tokens=None))]
+#[pyo3(signature = (payload, *, policy=None, format=None, mode=None, target_tokens=None, lossy=None, lossy_ratio=None, lossy_preserve=None))]
+#[allow(clippy::too_many_arguments)]
 fn inspect(
     py: Python<'_>,
     payload: PayloadArg,
@@ -671,6 +821,14 @@ fn inspect(
     format: Option<FormatArg>,
     mode: Option<ModeArg>,
     target_tokens: Option<usize>,
+    // Preview what `--lossy` would do without writing anything: `run_compress`'s `dry_run=true`
+    // sets `CompressionPolicy.preview`, which routes every store() call in the pipeline
+    // (including the lossy stage's) through a throwaway in-memory probe instead of the real
+    // retrieval backend -- so a dropped item that a real run would refuse to persist (e.g.
+    // secret-shaped content) gets put back here too, same as a real run would.
+    lossy: Option<LossyArg>,
+    lossy_ratio: Option<f64>,
+    lossy_preserve: Option<Vec<String>>,
 ) -> PyResult<PyCompressionResult> {
     let resolved_format = format
         .map(FormatArg::resolve)
@@ -684,6 +842,9 @@ fn inspect(
         mode,
         target_tokens,
         None,
+        lossy,
+        lossy_ratio,
+        lossy_preserve,
         // inspect() never applies compression, so a fail-closed budget gate would only get
         // in the way of a dry-run preview; always let it through.
         true,
@@ -711,6 +872,12 @@ fn compress_openai_payload(
         mode,
         target_tokens,
         disable,
+        // Lossy pruning only ever applies to generic JSON (core no-ops it on every other
+        // format), so this convenience wrapper doesn't expose it as its own kwarg -- always
+        // None, not a passthrough.
+        None,
+        None,
+        None,
         allow_heuristic_budget,
         false,
     )
@@ -736,6 +903,9 @@ fn compress_anthropic_payload(
         mode,
         target_tokens,
         disable,
+        None,
+        None,
+        None,
         allow_heuristic_budget,
         false,
     )
@@ -846,6 +1016,52 @@ fn compress_messages(
 }
 
 // ---------------------------------------------------------------------------------------
+// retrieve: restores a payload previously persisted by `store_originals=True` or `lossy`,
+// mirroring `tokenfold retrieve <hash>`. Unlike the CLI, this never accepts a text
+// `[tokenfold:retrieve ...]` marker or a CompressionReport file path -- a Python caller
+// working with a `$tf_ref` JSON marker already has it parsed
+// (`marker["$tf_ref"]["hash"]`/`["namespace"]`), so re-implementing the CLI's text-marker
+// grammar here would be redundant, not more convenient.
+// ---------------------------------------------------------------------------------------
+
+#[pyfunction]
+#[pyo3(signature = (hash, *, namespace=None, backend=None, retrieval_store_path=None, policy=None))]
+fn retrieve(
+    py: Python<'_>,
+    hash: String,
+    namespace: Option<String>,
+    backend: Option<String>,
+    retrieval_store_path: Option<PathBuf>,
+    policy: Option<PyRef<'_, PyCompressionPolicy>>,
+) -> PyResult<Py<PyBytes>> {
+    let base = policy.as_deref().map(|p| &p.0);
+    let resolved_namespace = namespace
+        .or_else(|| base.map(|p| p.retrieval_namespace.clone()))
+        .unwrap_or_else(|| "default".to_string());
+    let resolved_backend = backend
+        .or_else(|| base.map(|p| p.retrieval_backend.clone()))
+        .unwrap_or_else(|| "filesystem".to_string());
+    let resolved_store_path =
+        retrieval_store_path.or_else(|| base.and_then(|p| p.retrieval_store_path.clone()));
+
+    // Hash algorithm is hardcoded "sha256" here for the same reason every call site in
+    // tokenfold-core is: it is the only implemented option (`RetrievalStore::open` rejects
+    // "blake3" as a documented, not-yet-built scope cut).
+    let store =
+        RetrievalStore::open(&resolved_backend, "sha256", resolved_store_path).map_err(map_err)?;
+
+    match store.retrieve(&hash, &resolved_namespace) {
+        RetrievalOutcome::Found(bytes) => Ok(PyBytes::new(py, &bytes).unbind()),
+        RetrievalOutcome::Missing => Err(RetrievalError::new_err(format!(
+            "no stored original found for hash {hash:?} in namespace {resolved_namespace:?}"
+        ))),
+        RetrievalOutcome::Expired => Err(RetrievalError::new_err(format!(
+            "stored original for hash {hash:?} in namespace {resolved_namespace:?} has expired"
+        ))),
+    }
+}
+
+// ---------------------------------------------------------------------------------------
 // Module registration
 // ---------------------------------------------------------------------------------------
 
@@ -854,6 +1070,7 @@ fn tokenfold(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyCompressionMode>()?;
     m.add_class::<PyInputFormat>()?;
     m.add_class::<PyStatus>()?;
+    m.add_class::<PyLossyPath>()?;
     m.add_class::<PyCompressionPolicy>()?;
     m.add_class::<PyEstimatorInfo>()?;
     m.add_class::<PyCompressionReport>()?;
@@ -866,11 +1083,13 @@ fn tokenfold(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add("EstimatorError", py.get_type::<EstimatorError>())?;
     m.add("ConfigError", py.get_type::<ConfigError>())?;
     m.add("InternalError", py.get_type::<InternalError>())?;
+    m.add("RetrievalError", py.get_type::<RetrievalError>())?;
 
     m.add_function(wrap_pyfunction!(compress, m)?)?;
     m.add_function(wrap_pyfunction!(inspect, m)?)?;
     m.add_function(wrap_pyfunction!(compress_openai_payload, m)?)?;
     m.add_function(wrap_pyfunction!(compress_anthropic_payload, m)?)?;
     m.add_function(wrap_pyfunction!(compress_messages, m)?)?;
+    m.add_function(wrap_pyfunction!(retrieve, m)?)?;
     Ok(())
 }

--- a/examples/lossy_pruning.py
+++ b/examples/lossy_pruning.py
@@ -8,9 +8,11 @@ PowerShell:
     $env:TOKENFOLD_BIN = "target/release/tokenfold.exe"
     python examples/lossy_pruning.py
 
-Lossy pruning is CLI-only today -- the Python and TypeScript packages stay
-lossless -- so this drives the `tokenfold` binary via subprocess. Standard
-library only, no extra dependencies.
+This drives the `tokenfold` binary via subprocess so it runs against any install,
+standard library only, no extra dependencies. The same knobs are available
+in-process from the Python binding (`compress(..., lossy=LossyPath.HEURISTIC)`
+plus `retrieve()`) and from the TypeScript package (`compress(input, { lossy:
+"heuristic" })` plus `retrieve()`).
 
 Everything runs against a throwaway retrieval store in a temp directory, so it
 never touches the one your real runs use, and cleans up after itself.

--- a/examples/quickstart.ipynb
+++ b/examples/quickstart.ipynb
@@ -196,7 +196,7 @@
     "\n",
     "\n",
     "ANTHROPIC_PAYLOAD = json.dumps({\n",
-    "    \"model\": \"claude-3-5-sonnet-20241022\",\n",
+    "    \"model\": \"claude-sonnet-5\",\n",
     "    \"system\": \"You are a careful senior software engineer. You write correct, minimal \"\n",
     "              \"code and explain your reasoning briefly.\",\n",
     "    \"messages\": [\n",

--- a/examples/quickstart.ipynb
+++ b/examples/quickstart.ipynb
@@ -5,24 +5,26 @@
    "id": "intro",
    "metadata": {},
    "source": [
-    "# tokenfold quickstart (Python)",
-    "",
-    "The notebook version of [`quickstart.py`](quickstart.py) — same three operations, one",
-    "per cell, so you can poke at the receipts between steps.",
-    "",
-    "```",
-    "pip install tokenfold",
-    "```",
-    "",
-    "From a clone, build the binding instead:",
-    "",
-    "```",
-    "maturin develop -m crates/tokenfold-py/Cargo.toml",
-    "```",
-    "",
-    "Everything here is **lossless**: the Python binding only ever restructures data, never",
-    "discards it. Opt-in lossy array pruning is CLI-only today — see",
-    "[`lossy_pruning.py`](lossy_pruning.py) for that."
+    "# tokenfold quickstart (Python)\n",
+    "\n",
+    "The notebook version of [`quickstart.py`](quickstart.py) — the same core operations, one\n",
+    "per cell, so you can poke at the receipts between steps, plus two extras only the\n",
+    "notebook covers: the Anthropic-format helper and a dry-run preview with `inspect`.\n",
+    "\n",
+    "```\n",
+    "pip install tokenfold\n",
+    "```\n",
+    "\n",
+    "From a clone, build the binding instead:\n",
+    "\n",
+    "```\n",
+    "maturin develop -m crates/tokenfold-py/Cargo.toml\n",
+    "```\n",
+    "\n",
+    "Everything here is **lossless**: these calls only ever restructure data, never discard\n",
+    "it. Lossy array pruning is opt-in and stays off unless you ask for it\n",
+    "(`compress(..., lossy=LossyPath.HEURISTIC)`, recoverable via `retrieve()`) — see\n",
+    "[`lossy_pruning.py`](lossy_pruning.py) for that end to end."
    ]
   },
   {
@@ -47,10 +49,15 @@
    "id": "m1",
    "metadata": {},
    "source": [
-    "## 1. Compress a message list",
-    "",
-    "The common case: you have a `messages` list bound for the Chat Completions API.",
-    "`compress_messages` hands back a compressed list plus exact token accounting."
+    "## 1. Compress a message list\n",
+    "\n",
+    "The common case: you have a `messages` list bound for the Chat Completions API.\n",
+    "`compress_messages` hands back a compressed list plus exact token accounting.\n",
+    "\n",
+    "The example below is deliberately messy: a debugging session where someone pasted\n",
+    "live-looking secrets into the chat. `compress_messages` redacts them before the\n",
+    "request ever goes out, and the token savings below are the real, measured effect of\n",
+    "that — not a hypothetical."
    ]
   },
   {
@@ -60,7 +67,33 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "result = tokenfold.compress_messages(PAYLOAD[\"messages\"], model=\"gpt-4o\", mode=\"BALANCED\")\n",
+    "# A realistic slip: someone pastes their whole .env into a debugging chat.\n",
+    "# tokenfold catches and redacts every secret before this reaches the API --\n",
+    "# redaction is best-effort (see the warning below), never a substitute for not\n",
+    "# leaking secrets in the first place.\n",
+    "JWT = (\n",
+    "    \"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.\"\n",
+    "    \"eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U\"\n",
+    ")\n",
+    "messages = [\n",
+    "    {\"role\": \"system\", \"content\": \"You are a careful senior software engineer.\"},\n",
+    "    {\n",
+    "        \"role\": \"user\",\n",
+    "        \"content\": (\n",
+    "            \"Deploy is failing. Here is the full .env I'm using, can you spot the \"\n",
+    "            \"problem?\\n\\n\"\n",
+    "            'OPENAI_API_KEY=sk-ThisIsNotARealKey1234567890ABCDEF\\n'\n",
+    "            'STRIPE_SECRET_KEY=sk-AnotherFakeSecretKeyForStripe0987654321XY\\n'\n",
+    "            'AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE\\n'\n",
+    "            'DATABASE_URL=https://admin:hunter2@prod-db.internal:5432/app\\n'\n",
+    "            'REPLICA_URL=https://readonly:swordfish@prod-db-replica.internal:5432/app\\n'\n",
+    "            f'AUTH_HEADER=Bearer {JWT}\\n'\n",
+    "            f'SESSION_TOKEN=Bearer {JWT}\\n'\n",
+    "        ),\n",
+    "    },\n",
+    "]\n",
+    "\n",
+    "result = tokenfold.compress_messages(messages, model=\"gpt-4o\", mode=\"BALANCED\")\n",
     "\n",
     "print(f\"tokens:     {result.tokens_before} -> {result.tokens_after} \"\n",
     "      f\"({result.tokens_saved} saved, {result.savings_pct:.1f}%)\")\n",
@@ -75,9 +108,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# `result.messages` is the compressed list — send it straight to your provider:\n",
+    "# `result.messages` is the compressed list -- send it straight to your provider.\n",
+    "# The secrets above never leave this process:\n",
     "#   client.chat.completions.create(model=\"gpt-4o\", messages=result.messages)\n",
-    "result.messages[-1]"
+    "result.messages[-1]  # the redacted version of the message above"
    ]
   },
   {
@@ -85,9 +119,9 @@
    "id": "m2",
    "metadata": {},
    "source": [
-    "## 2. Compress a raw request body",
-    "",
-    "`compress` is the bytes-first core API. Give it a whole request body — messages *and*",
+    "## 2. Compress a raw request body\n",
+    "\n",
+    "`compress` is the bytes-first core API. Give it a whole request body — messages *and*\n",
     "the verbose tool schema — and pick the format."
    ]
   },
@@ -114,14 +148,98 @@
   },
   {
    "cell_type": "markdown",
+   "id": "m2b",
+   "metadata": {},
+   "source": [
+    "## 3. Same, but for Anthropic-style requests\n",
+    "\n",
+    "Every provider gets a matching one-liner: `compress_openai_payload` and\n",
+    "`compress_anthropic_payload` are `compress(..., format=...)` with the format\n",
+    "pre-selected. Anthropic's Messages API keeps `system` outside the `messages` array\n",
+    "and tool schemas under `input_schema` — the compressor already knows both shapes.\n",
+    "A small toolset like this one, where every tool shares the same parameter shape, is\n",
+    "close to the ceiling for this format: provider request bodies stay wire-compatible,\n",
+    "so schema compaction and whitespace removal are the whole budget — there's no\n",
+    "columnar folding here the way there is for generic JSON in the next section."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c2b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "LOCATION_PARAM = {\n",
+    "    \"type\": \"string\",\n",
+    "    \"description\": \"The city and state, e.g. San Francisco, CA\",\n",
+    "    \"examples\": [\"San Francisco, CA\", \"New York, NY\", \"Austin, TX\", \"Seattle, WA\"],\n",
+    "}\n",
+    "UNIT_PARAM = {\n",
+    "    \"type\": \"string\",\n",
+    "    \"enum\": [\"celsius\", \"fahrenheit\"],\n",
+    "    \"description\": \"The unit to return the temperature in.\",\n",
+    "    \"examples\": [\"celsius\", \"fahrenheit\"],\n",
+    "}\n",
+    "\n",
+    "\n",
+    "def location_tool(name, description):\n",
+    "    return {\n",
+    "        \"name\": name,\n",
+    "        \"description\": description,\n",
+    "        \"input_schema\": {\n",
+    "            \"type\": \"object\",\n",
+    "            \"properties\": {\"location\": LOCATION_PARAM, \"unit\": UNIT_PARAM},\n",
+    "            \"required\": [\"location\"],\n",
+    "        },\n",
+    "    }\n",
+    "\n",
+    "\n",
+    "ANTHROPIC_PAYLOAD = json.dumps({\n",
+    "    \"model\": \"claude-3-5-sonnet-20241022\",\n",
+    "    \"system\": \"You are a careful senior software engineer. You write correct, minimal \"\n",
+    "              \"code and explain your reasoning briefly.\",\n",
+    "    \"messages\": [\n",
+    "        {\"role\": \"user\", \"content\": \"Can you show me the tool schemas for weather lookups?\"},\n",
+    "        {\"role\": \"assistant\", \"content\": \"Sure -- here are the weather tools available.\"},\n",
+    "        {\"role\": \"user\", \"content\": \"Great, now compress the schema and tell me what changed.\"},\n",
+    "    ],\n",
+    "    # Five tools sharing the same location/unit shape -- a realistic small toolset,\n",
+    "    # and exactly the kind of repetition schema_compaction is built to fold.\n",
+    "    \"tools\": [\n",
+    "        location_tool(\"get_weather\", \"Look up the current weather for a given location.\"),\n",
+    "        location_tool(\"get_forecast\", \"Look up the multi-day forecast for a given location.\"),\n",
+    "        location_tool(\"get_air_quality\", \"Look up the current air quality index for a given location.\"),\n",
+    "        location_tool(\"get_uv_index\", \"Look up the current UV index for a given location.\"),\n",
+    "        location_tool(\"get_pollen_count\", \"Look up the current pollen count for a given location.\"),\n",
+    "    ],\n",
+    "})\n",
+    "\n",
+    "result = tokenfold.compress_anthropic_payload(ANTHROPIC_PAYLOAD, mode=\"BALANCED\")\n",
+    "report = result.report\n",
+    "\n",
+    "print(f\"status:     {report.status}\")\n",
+    "print(f\"tokens:     {report.original_tokens} -> {report.compressed_tokens} \"\n",
+    "      f\"({report.saved_tokens} saved, {report.savings_pct:.1f}%)\")\n",
+    "print(f\"estimator:  {report.estimator.backend} (exact: {report.estimator.is_exact})\")\n",
+    "for w in report.warnings:\n",
+    "    print(f\"  warning: {w}\")\n",
+    "print(f\"payload:    {len(result.payload)} bytes\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "m3",
    "metadata": {},
    "source": [
-    "## 3. Compress generic JSON data",
-    "",
-    "Not every payload is a message list. `format=\"JSON\"` compresses API responses, records,",
-    "and logs: repeated keys fold into columnar form, repeated values into a dictionary. Both",
-    "are losslessly reversible — every stage is round-trip gated before it's applied."
+    "## 4. Compress generic JSON data\n",
+    "\n",
+    "Not every payload is a message list. `format=\"JSON\"` compresses API responses, records,\n",
+    "and logs: repeated keys fold into columnar form, repeated values into a dictionary. Both\n",
+    "are losslessly reversible — every stage is round-trip gated before it's applied. Unlike\n",
+    "the provider formats above, this one doesn't have to stay wire-compatible with anything,\n",
+    "so it can restructure freely — a support-ticket feed like the one below, where a small\n",
+    "team rotates through many tickets, folds hard."
    ]
   },
   {
@@ -131,7 +249,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data = Path(\"api_response.json\").read_text()\n",
+    "# A support-ticket routing feed: the same 4 agents and 4 statuses recur across every\n",
+    "# ticket, and every ticket shares the same team/priority/sla_tier -- a realistic case\n",
+    "# where almost the whole payload is repeated keys and values.\n",
+    "AGENTS = [\"Ada Lovelace\", \"Alan Turing\", \"Grace Hopper\", \"Barbara Liskov\"]\n",
+    "STATUSES = [\"open\", \"in_progress\", \"resolved\", \"closed\"]\n",
+    "tickets = [\n",
+    "    {\n",
+    "        \"assigned_to\": AGENTS[i % len(AGENTS)],\n",
+    "        \"status\": STATUSES[i % len(STATUSES)],\n",
+    "        \"priority\": \"normal\",\n",
+    "        \"team\": \"platform-support\",\n",
+    "        \"sla_tier\": \"standard\",\n",
+    "    }\n",
+    "    for i in range(50)\n",
+    "]\n",
+    "data = json.dumps({\"status\": \"ok\", \"count\": len(tickets), \"tickets\": tickets})\n",
+    "\n",
     "result = tokenfold.compress(data, format=\"JSON\", mode=\"BALANCED\")\n",
     "report = result.report\n",
     "\n",
@@ -144,13 +278,43 @@
   },
   {
    "cell_type": "markdown",
+   "id": "m3b",
+   "metadata": {},
+   "source": [
+    "## 5. Preview without compressing (dry run)\n",
+    "\n",
+    "`inspect` runs the same safety checks and reports what *would* happen, but hands your\n",
+    "bytes back untouched — use it to decide whether compressing is worth it before you\n",
+    "commit to it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c3b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "preview = tokenfold.inspect(data, format=\"JSON\", mode=\"BALANCED\")\n",
+    "preview_report = preview.report\n",
+    "\n",
+    "would_apply = [t[\"id\"] for t in preview_report.raw[\"transforms\"] if t[\"status\"] == \"applied\"]\n",
+    "print(f\"would apply: {', '.join(would_apply)}\")\n",
+    "print(f\"projected:   {preview_report.original_tokens} -> {preview_report.compressed_tokens} \"\n",
+    "      f\"({preview_report.saved_tokens} saved, {preview_report.savings_pct:.1f}%)\")\n",
+    "print(f\"payload:     {len(preview.payload)} bytes -- your input, handed back unchanged\")\n",
+    "assert preview.payload == data.encode(\"utf-8\"), \"inspect() must never modify the input\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "m4",
    "metadata": {},
    "source": [
-    "## 4. Read the whole receipt",
-    "",
-    "tokenfold never silently drops content — you get receipts. The promoted attributes above",
-    "are a subset; `report.raw` is the full report as a plain dict, which is where `quality`,",
+    "## 6. Read the whole receipt\n",
+    "\n",
+    "tokenfold never silently drops content — you get receipts. The promoted attributes above\n",
+    "are a subset; `report.raw` is the full report as a plain dict, which is where `quality`,\n",
     "`budget`, `cache`, `retrieval`, and the per-transform breakdown live."
    ]
   },
@@ -183,11 +347,11 @@
    "id": "m5",
    "metadata": {},
    "source": [
-    "## Where to next",
-    "",
-    "- [`quickstart.py`](quickstart.py) — the same three operations as a plain script",
-    "- [`quickstart.mjs`](quickstart.mjs) — the TypeScript/Node package",
-    "- [`quickstart.rs`](quickstart.rs) — the embedded Rust core API",
+    "## Where to next\n",
+    "\n",
+    "- [`quickstart.py`](quickstart.py) — the same three operations as a plain script\n",
+    "- [`quickstart.mjs`](quickstart.mjs) — the TypeScript/Node package\n",
+    "- [`quickstart.rs`](quickstart.rs) — the embedded Rust core API\n",
     "- [`lossy_pruning.py`](lossy_pruning.py) — opt-in recoverable pruning, CLI-driven"
    ]
   }
@@ -199,7 +363,16 @@
    "name": "python3"
   },
   "language_info": {
-   "name": "python"
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.13"
   }
  },
  "nbformat": 4,

--- a/examples/quickstart.ipynb
+++ b/examples/quickstart.ipynb
@@ -1,0 +1,207 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "intro",
+   "metadata": {},
+   "source": [
+    "# tokenfold quickstart (Python)",
+    "",
+    "The notebook version of [`quickstart.py`](quickstart.py) — same three operations, one",
+    "per cell, so you can poke at the receipts between steps.",
+    "",
+    "```",
+    "pip install tokenfold",
+    "```",
+    "",
+    "From a clone, build the binding instead:",
+    "",
+    "```",
+    "maturin develop -m crates/tokenfold-py/Cargo.toml",
+    "```",
+    "",
+    "Everything here is **lossless**: the Python binding only ever restructures data, never",
+    "discards it. Opt-in lossy array pruning is CLI-only today — see",
+    "[`lossy_pruning.py`](lossy_pruning.py) for that."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "setup",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "from pathlib import Path\n",
+    "\n",
+    "import tokenfold\n",
+    "\n",
+    "# The same payload the Rust and Node examples use.\n",
+    "PAYLOAD = json.loads(Path(\"openai_payload.json\").read_text())\n",
+    "[m[\"role\"] for m in PAYLOAD[\"messages\"]]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "m1",
+   "metadata": {},
+   "source": [
+    "## 1. Compress a message list",
+    "",
+    "The common case: you have a `messages` list bound for the Chat Completions API.",
+    "`compress_messages` hands back a compressed list plus exact token accounting."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "result = tokenfold.compress_messages(PAYLOAD[\"messages\"], model=\"gpt-4o\", mode=\"BALANCED\")\n",
+    "\n",
+    "print(f\"tokens:     {result.tokens_before} -> {result.tokens_after} \"\n",
+    "      f\"({result.tokens_saved} saved, {result.savings_pct:.1f}%)\")\n",
+    "print(f\"transforms: {', '.join(result.transforms_applied) or '(none applied)'}\")\n",
+    "print(f\"messages:   {len(result.messages)} message(s) ready to send\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c1b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# `result.messages` is the compressed list — send it straight to your provider:\n",
+    "#   client.chat.completions.create(model=\"gpt-4o\", messages=result.messages)\n",
+    "result.messages[-1]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "m2",
+   "metadata": {},
+   "source": [
+    "## 2. Compress a raw request body",
+    "",
+    "`compress` is the bytes-first core API. Give it a whole request body — messages *and*",
+    "the verbose tool schema — and pick the format."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "result = tokenfold.compress(json.dumps(PAYLOAD), format=\"OPENAI_JSON\", mode=\"BALANCED\")\n",
+    "report = result.report\n",
+    "\n",
+    "# `best_effort` here means \"no target_tokens to confirm against\", not a failure:\n",
+    "# `compressed` is reserved for runs that provably met a target you asked for.\n",
+    "print(f\"status:     {report.status}\")\n",
+    "print(f\"tokens:     {report.original_tokens} -> {report.compressed_tokens} \"\n",
+    "      f\"({report.saved_tokens} saved, {report.savings_pct:.1f}%)\")\n",
+    "print(f\"estimator:  {report.estimator.backend} (exact: {report.estimator.is_exact})\")\n",
+    "for w in report.warnings:\n",
+    "    print(f\"  warning: {w}\")\n",
+    "print(f\"payload:    {len(result.payload)} bytes\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "m3",
+   "metadata": {},
+   "source": [
+    "## 3. Compress generic JSON data",
+    "",
+    "Not every payload is a message list. `format=\"JSON\"` compresses API responses, records,",
+    "and logs: repeated keys fold into columnar form, repeated values into a dictionary. Both",
+    "are losslessly reversible — every stage is round-trip gated before it's applied."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data = Path(\"api_response.json\").read_text()\n",
+    "result = tokenfold.compress(data, format=\"JSON\", mode=\"BALANCED\")\n",
+    "report = result.report\n",
+    "\n",
+    "applied = [t[\"id\"] for t in report.raw[\"transforms\"] if t[\"status\"] == \"applied\"]\n",
+    "print(f\"tokens:     {report.original_tokens} -> {report.compressed_tokens} \"\n",
+    "      f\"({report.saved_tokens} saved, {report.savings_pct:.1f}%)\")\n",
+    "print(f\"transforms: {', '.join(applied)}\")\n",
+    "print(f\"bytes:      {len(data)} -> {len(result.payload)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "m4",
+   "metadata": {},
+   "source": [
+    "## 4. Read the whole receipt",
+    "",
+    "tokenfold never silently drops content — you get receipts. The promoted attributes above",
+    "are a subset; `report.raw` is the full report as a plain dict, which is where `quality`,",
+    "`budget`, `cache`, `retrieval`, and the per-transform breakdown live."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "row = \"{:<18} {:<10} {:>7} {:>7} {:>7}\"\n",
+    "print(row.format(\"TRANSFORM\", \"STATUS\", \"BEFORE\", \"AFTER\", \"SAVED\"))\n",
+    "for t in report.raw[\"transforms\"]:\n",
+    "    print(row.format(t[\"id\"], t[\"status\"], t[\"tokens_before\"], t[\"tokens_after\"], t[\"saved_tokens\"]))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Everything the transform table leaves out:\n",
+    "{k: v for k, v in report.raw.items() if k != \"transforms\"}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "m5",
+   "metadata": {},
+   "source": [
+    "## Where to next",
+    "",
+    "- [`quickstart.py`](quickstart.py) — the same three operations as a plain script",
+    "- [`quickstart.mjs`](quickstart.mjs) — the TypeScript/Node package",
+    "- [`quickstart.rs`](quickstart.rs) — the embedded Rust core API",
+    "- [`lossy_pruning.py`](lossy_pruning.py) — opt-in recoverable pruning, CLI-driven"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/quickstart.mjs
+++ b/examples/quickstart.mjs
@@ -1,0 +1,109 @@
+/**
+ * Real-world quickstart for the `tokenfold` npm package.
+ *
+ * Install the package, then run this file:
+ *
+ *     npm install tokenfold
+ *     node examples/quickstart.mjs
+ *
+ * From a clone, build the local package and point it at a local CLI build:
+ *
+ *     cargo build --release -p tokenfold-cli
+ *     npm --prefix packages/tokenfold ci && npm --prefix packages/tokenfold run build
+ *     TOKENFOLD_BINARY_PATH=target/release/tokenfold node examples/quickstart.mjs
+ *
+ * PowerShell:
+ *
+ *     $env:TOKENFOLD_BINARY_PATH = "target/release/tokenfold.exe"
+ *     node examples/quickstart.mjs
+ *
+ * It shows the three things you'll actually do in an app:
+ *
+ *   1. compress(body, { format: "openai" }) -- compress a chat-completion request
+ *      body before you send it, and read the exact token accounting off the receipt.
+ *   2. compress(data, { format: "json" }) -- compress generic JSON *data* (API
+ *      responses, records, logs). Losslessly folds repeated keys and values.
+ *   3. inspect(...) -- dry run. Same receipt, your bytes handed back untouched, so
+ *      you can decide whether compressing is worth it before you commit to it.
+ *
+ * Every call returns `{ payload, report }`: `payload` is bytes ready to send, and
+ * `report` carries before/after tokens, which transforms ran, and any safety
+ * warnings. tokenfold never silently drops content -- you get receipts.
+ *
+ * Everything here is lossless: the TypeScript package only ever restructures data,
+ * never discards it. Opt-in lossy array pruning is CLI-only today -- see
+ * `examples/lossy_pruning.py` for that. Node's standard library only, no extra deps.
+ */
+
+import { readFile } from "node:fs/promises";
+
+// Prefer the published package; fall back to this repo's own build so a clone can run
+// the example without installing anything from npm.
+const { compress, inspect } = await import("tokenfold").catch(() =>
+  import(new URL("../packages/tokenfold/dist/index.js", import.meta.url).href).catch(() => {
+    console.error(
+      "tokenfold not found. Install it (`npm install tokenfold`), or build the local\n" +
+        "package first:\n" +
+        "    npm --prefix packages/tokenfold ci && npm --prefix packages/tokenfold run build",
+    );
+    process.exit(1);
+  }),
+);
+
+const here = (name) => new URL(name, import.meta.url);
+
+const applied = (report) =>
+  report.transforms.filter((t) => t.status === "applied").map((t) => t.id);
+
+function printTokens(report) {
+  console.log(
+    `tokens:     ${report.original_tokens} -> ${report.compressed_tokens} ` +
+      `(${report.saved_tokens} saved, ${report.savings_pct.toFixed(1)}%)`,
+  );
+}
+
+// --- 1. A provider request body (chat messages + a verbose tool schema) -------------
+async function compressAnOpenAiBody() {
+  // The same payload the Rust and Python examples use (examples/openai_payload.json).
+  const body = await readFile(here("openai_payload.json"));
+  const { payload, report } = await compress(body, { format: "openai", mode: "balanced" });
+
+  console.log("== compress (OpenAI request body) ==");
+  // `best_effort` here means "no --target-tokens to confirm against", not a failure:
+  // `compressed` is reserved for runs that provably met a target you asked for.
+  console.log(`status:     ${report.status}`);
+  printTokens(report);
+  console.log(`estimator:  ${report.estimator.backend} (exact: ${report.estimator.is_exact})`);
+  for (const w of report.warnings) console.log(`  warning: ${w.message}`);
+  // `payload` is the compressed body -- POST it to the provider as-is:
+  //   await fetch(url, { method: "POST", body: payload });
+  console.log(`payload:    ${payload.length} bytes ready to send\n`);
+}
+
+// --- 2. Generic JSON data (API response, records, logs) ------------------------------
+async function compressGenericJsonData() {
+  const data = await readFile(here("api_response.json"));
+  const { payload, report } = await compress(data, { format: "json", mode: "balanced" });
+
+  console.log("== compress (generic JSON data) ==");
+  printTokens(report);
+  console.log(`transforms: ${applied(report).join(", ")}`);
+  // Columnar folding plus a value dictionary, losslessly reversible -- every stage is
+  // round-trip gated before it's applied.
+  console.log(`payload:    ${payload.length} bytes\n`);
+}
+
+// --- 3. Dry run: what would compressing buy me? --------------------------------------
+async function inspectBeforeCommitting() {
+  const data = await readFile(here("api_response.json"));
+  const { payload, report } = await inspect(data, { format: "json" });
+
+  console.log("== inspect (dry run) ==");
+  printTokens(report);
+  console.log(`would apply: ${applied(report).join(", ")}`);
+  console.log(`payload:    ${payload.length} bytes -- your input, handed back unchanged\n`);
+}
+
+await compressAnOpenAiBody();
+await compressGenericJsonData();
+await inspectBeforeCommitting();

--- a/examples/quickstart.mjs
+++ b/examples/quickstart.mjs
@@ -30,9 +30,10 @@
  * `report` carries before/after tokens, which transforms ran, and any safety
  * warnings. tokenfold never silently drops content -- you get receipts.
  *
- * Everything here is lossless: the TypeScript package only ever restructures data,
- * never discards it. Opt-in lossy array pruning is CLI-only today -- see
- * `examples/lossy_pruning.py` for that. Node's standard library only, no extra deps.
+ * Everything here is lossless: these calls only ever restructure data, never discard
+ * it. Lossy array pruning is opt-in and stays off unless you ask for it
+ * (`compress(input, { lossy: "heuristic" })`) -- see `examples/lossy_pruning.py` for
+ * that end to end. Node's standard library only, no extra deps.
  */
 
 import { readFile } from "node:fs/promises";

--- a/examples/quickstart.py
+++ b/examples/quickstart.py
@@ -60,6 +60,8 @@ def compress_a_raw_body() -> None:
     report = result.report
 
     print("== compress (raw OpenAI body) ==")
+    # `best_effort` here means "no target_tokens to confirm against", not a failure:
+    # `compressed` is reserved for runs that provably met a target you asked for.
     print(f"status:     {report.status}")
     print(
         f"tokens:     {report.original_tokens} -> {report.compressed_tokens} "

--- a/examples/quickstart.py
+++ b/examples/quickstart.py
@@ -16,9 +16,10 @@ It shows the three things you'll actually do in an app:
 Every call returns a typed report: before/after tokens, which transforms ran, and any
 safety warnings. tokenfold never silently drops content — you get receipts.
 
-Everything here is lossless: the Python binding only ever restructures data, never
-discards it. Opt-in lossy array pruning is CLI-only today — see
-`examples/lossy_pruning.py` for that.
+Everything here is lossless: these calls only ever restructure data, never discard it.
+Lossy array pruning is opt-in and stays off unless you ask for it
+(`compress(..., lossy=LossyPath.HEURISTIC)`) — see `examples/lossy_pruning.py`
+for that end to end.
 """
 
 import json

--- a/examples/quickstart.rs
+++ b/examples/quickstart.rs
@@ -12,10 +12,10 @@
 
 use tokenfold_core::{CompressionInput, CompressionMode, CompressionPolicy, compress};
 
-// The payloads ship with the repo. Embedding them with include_str! keeps this example
+// The payloads sit beside this file. Embedding them with include_str! keeps this example
 // runnable from any working directory.
-const PAYLOAD: &str = include_str!("../../../examples/openai_payload.json");
-const API_RESPONSE: &str = include_str!("../../../examples/api_response.json");
+const PAYLOAD: &str = include_str!("openai_payload.json");
+const API_RESPONSE: &str = include_str!("api_response.json");
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     compress_openai_body()?;

--- a/packages/tokenfold/README.md
+++ b/packages/tokenfold/README.md
@@ -15,5 +15,24 @@ const { payload, report } = await compress(input, {
 });
 ```
 
+Opt-in lossy array pruning drops whole array items to hit a token budget instead
+of only restructuring them, replacing each with a `$tf_ref` marker that resolves
+through the local retrieval store. Generic JSON only:
+
+```ts
+import { compress, retrieve } from "tokenfold";
+
+const { payload, report } = await compress(feed, {
+  format: "json",
+  lossy: "heuristic",
+  lossyRatio: 0.35,        // selection hint, not an enforced budget
+  lossyPreserve: ["meta"], // arrays that are never pruned
+});
+const original = await retrieve(hash); // a dropped item's original bytes
+```
+
+Pass the same options to `inspect` to preview the projected savings without
+writing anything to the store.
+
 Requires Node.js 22 or newer. The matching native CLI is installed through an
 optional platform package; set `TOKENFOLD_BINARY_PATH` to use a custom binary.

--- a/packages/tokenfold/src/index.ts
+++ b/packages/tokenfold/src/index.ts
@@ -17,6 +17,9 @@ export type TaskScope =
   | "retrieval_qa"
   | "agent_history";
 
+/** Selection backend for opt-in lossy pruning. `heuristic` is the only Phase 1 path. */
+export type LossyPath = "heuristic";
+
 export interface CompressionOptions {
   format?: "auto" | "openai" | "anthropic" | "json" | "text" | "command" | "diff";
   mode?: CompressionMode;
@@ -26,6 +29,22 @@ export interface CompressionOptions {
   experimental?: boolean;
   storeOriginals?: boolean;
   retrieveNamespace?: string;
+  /**
+   * Opt-in LOSSY JSON array-item pruning (`--lossy`): drops whole array items to hit a token
+   * budget instead of only restructuring them. Generic JSON only — on any other format the run
+   * is a no-op and `json_prune` comes back as `status: "skipped"` with
+   * `skipped_reason: "not_applicable_to_format"`, persisting nothing. Dropped items are replaced
+   * by `$tf_ref` markers and stay recoverable via {@link retrieve}; pruning needs a durable
+   * filesystem retrieval store, so pass `configPath` when you want one other than the default.
+   */
+  lossy?: LossyPath;
+  /**
+   * `--lossy-ratio`: a best-effort selection hint (0.0..=1.0), not an enforced budget — the
+   * achieved ratio differs by design. Use `targetTokens` for a real ceiling.
+   */
+  lossyRatio?: number;
+  /** `--lossy-preserve`: dot-separated paths (e.g. `data.results`) whose arrays are never pruned. */
+  lossyPreserve?: readonly string[];
   configPath?: string;
   signal?: AbortSignal;
 }
@@ -153,16 +172,33 @@ export interface CompressionResult {
 }
 
 function argumentsFor(command: "compress" | "inspect", options: CompressionOptions): string[] {
-  const args = [command, "--json"];
+  // The `inspect` subcommand has no --lossy flags of its own; the CLI's lossy preview is
+  // `compress --dry-run`, which routes to the same code path and, exactly like `inspect --json`,
+  // writes the report to stdout and no payload. So a lossy inspect() becomes that instead.
+  const wantsLossy =
+    options.lossy !== undefined ||
+    options.lossyRatio !== undefined ||
+    (options.lossyPreserve?.length ?? 0) > 0;
+  const previewLossy = command === "inspect" && wantsLossy;
+  const args = previewLossy ? ["compress", "--json", "--dry-run"] : [command, "--json"];
+  const compressing = command === "compress" || previewLossy;
   if (options.format) args.push("--format", options.format);
   if (options.mode) args.push("--mode", options.mode);
   if (options.targetTokens !== undefined) args.push("--target-tokens", String(options.targetTokens));
-  if (options.disable?.length && command === "compress") args.push("--disable", options.disable.join(","));
+  if (options.disable?.length && compressing) args.push("--disable", options.disable.join(","));
   if (options.taskScope) args.push("--task-scope", options.taskScope);
   if (options.experimental) args.push("--experimental");
-  if (options.storeOriginals && command === "compress") args.push("--store-originals");
-  if (options.retrieveNamespace && command === "compress") {
+  if (options.storeOriginals && compressing) args.push("--store-originals");
+  if (options.retrieveNamespace && compressing) {
     args.push("--retrieve-namespace", options.retrieveNamespace);
+  }
+  if (wantsLossy && compressing) {
+    // `--lossy-ratio`/`--lossy-preserve` are `requires = "lossy"` in the CLI. Forward them even
+    // when `lossy` is unset rather than dropping them: silently ignoring a pruning-aggression
+    // knob is worse than the CLI's own "the following required arguments were not provided".
+    if (options.lossy) args.push("--lossy", options.lossy);
+    if (options.lossyRatio !== undefined) args.push("--lossy-ratio", String(options.lossyRatio));
+    for (const path of options.lossyPreserve ?? []) args.push("--lossy-preserve", path);
   }
   if (options.configPath) args.push("--config", options.configPath);
   return args;
@@ -182,6 +218,16 @@ function parseReport(bytes: Uint8Array, result: ProcessResult): CompressionRepor
   }
 }
 
+function throwIfFailed(result: ProcessResult): void {
+  if (result.exitCode === 0) return;
+  throw new TokenFoldProcessError(`tokenfold exited with status ${result.exitCode ?? result.signal}`, {
+    code: "tokenfold_exit",
+    exitCode: result.exitCode,
+    signal: result.signal,
+    stderr: result.stderr,
+  });
+}
+
 async function execute(
   command: "compress" | "inspect",
   input: Input,
@@ -193,14 +239,7 @@ async function execute(
   };
   if (options.signal) runOptions.signal = options.signal;
   const result = await run(argumentsFor(command, options), runOptions);
-  if (result.exitCode !== 0) {
-    throw new TokenFoldProcessError(`tokenfold exited with status ${result.exitCode ?? result.signal}`, {
-      code: "tokenfold_exit",
-      exitCode: result.exitCode,
-      signal: result.signal,
-      stderr: result.stderr,
-    });
-  }
+  throwIfFailed(result);
 
   const reportBytes = command === "compress" ? result.stderr : result.stdout;
   return {
@@ -215,4 +254,33 @@ export function compress(input: Input, options: CompressionOptions = {}): Promis
 
 export function inspect(input: Input, options: CompressionOptions = {}): Promise<CompressionResult> {
   return execute("inspect", input, options);
+}
+
+export interface RetrieveOptions {
+  /** `--retrieve-namespace`: the namespace the item was stored under. */
+  namespace?: string;
+  configPath?: string;
+  signal?: AbortSignal;
+}
+
+/**
+ * Restores the original bytes of something a lossy run dropped, or a `storeOriginals` run saved,
+ * mirroring `tokenfold retrieve`. `reference` is either a raw hex SHA-256 hash — a compressed
+ * payload's `$tf_ref.hash` — or a `[tokenfold:retrieve hash=... namespace=...]` text marker,
+ * whose embedded namespace is used when `options.namespace` is omitted. A CompressionReport
+ * path is NOT a valid reference: the current report schema carries no per-entry hash, and the
+ * CLI rejects it rather than guessing.
+ *
+ * Throws `TokenFoldProcessError` (`code: "tokenfold_exit"`) when the hash is unknown, its TTL
+ * has elapsed, or the reference is malformed — the CLI reports all of those as a non-zero exit.
+ */
+export async function retrieve(reference: string, options: RetrieveOptions = {}): Promise<Uint8Array> {
+  const args = ["retrieve", reference];
+  if (options.namespace) args.push("--retrieve-namespace", options.namespace);
+  if (options.configPath) args.push("--config", options.configPath);
+  const runOptions: RunOptions = { env: { TOKENFOLD_ANALYTICS_ENABLED: "false" } };
+  if (options.signal) runOptions.signal = options.signal;
+  const result = await run(args, runOptions);
+  throwIfFailed(result);
+  return result.stdout;
 }

--- a/packages/tokenfold/test/api.test.mjs
+++ b/packages/tokenfold/test/api.test.mjs
@@ -1,16 +1,56 @@
 import assert from "node:assert/strict";
+import { mkdtempSync, readdirSync, writeFileSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import test from "node:test";
 import {
   TokenFoldProcessError,
   binaryPath,
   compress,
   inspect,
+  retrieve,
   run,
 } from "../dist/index.js";
 
 const testBinary = process.env.TOKENFOLD_TEST_BINARY;
 if (!testBinary) throw new Error("TOKENFOLD_TEST_BINARY must point to a tokenfold 0.4.0 binary");
 process.env.TOKENFOLD_BINARY_PATH = testBinary;
+
+// A heterogeneous incident feed: lossless folding has a ceiling on it, so lossy pruning
+// actually drops items here. Shared with examples/lossy_pruning.py and the Python binding tests.
+const INCIDENT_FEED = path.join(import.meta.dirname, "..", "..", "..", "examples", "incident_feed.json");
+
+/**
+ * Every lossy run persists dropped items, so each test gets its own throwaway retrieval store
+ * and never touches the one a real run uses. Returns { configPath, storePath }.
+ */
+function throwawayStore() {
+  const dir = mkdtempSync(path.join(tmpdir(), "tokenfold-lossy-"));
+  const storePath = path.join(dir, "store");
+  const configPath = path.join(dir, "tokenfold.toml");
+  writeFileSync(
+    configPath,
+    `[retrieval]
+backend = "filesystem"
+store_path = "${storePath.replaceAll("\\", "/")}"
+`,
+  );
+  return { configPath, storePath };
+}
+
+function markerHashes(payload) {
+  const hashes = [];
+  const walk = (node) => {
+    if (Array.isArray(node)) node.forEach(walk);
+    else if (node && typeof node === "object") {
+      if (node.$tf_ref?.hash) hashes.push(node.$tf_ref.hash);
+      else Object.values(node).forEach(walk);
+    }
+  };
+  walk(JSON.parse(Buffer.from(payload).toString("utf8")));
+  return hashes;
+}
 
 test("resolves an explicit binary and reports its version", async () => {
   assert.equal(binaryPath(), testBinary);
@@ -112,4 +152,231 @@ test("high-level calls forward abort signals", async () => {
     assert.equal(error.code, "spawn_failed");
     return true;
   });
+});
+
+test("lossy pruning beats lossless and the planted incident survives", async () => {
+  const { configPath } = throwawayStore();
+  const input = await readFile(INCIDENT_FEED);
+  const lossless = await compress(input, { configPath, format: "json" });
+  const lossy = await compress(input, {
+    configPath,
+    format: "json",
+    lossy: "heuristic",
+    lossyRatio: 0.35,
+  });
+
+  assert.ok(
+    lossy.report.saved_tokens > lossless.report.saved_tokens,
+    "lossy pruning must save strictly more than the lossless pipeline on this fixture -- if " +
+      "this regresses, the fixture no longer exercises json_prune at all",
+  );
+  assert.equal(lossy.report.transforms.find(({ id }) => id === "json_prune")?.status, "applied");
+  assert.ok((lossy.report.retrieval?.marker_count ?? 0) > 0);
+
+  const events = JSON.parse(Buffer.from(lossy.payload).toString("utf8")).events;
+  const kept = events.filter((event) => !event.$tf_ref);
+  const dropped = events.filter((event) => event.$tf_ref);
+  assert.ok(dropped.length > 0, "this fixture must exercise pruning");
+  assert.ok(
+    kept.some((event) => event.status_code === 503),
+    "the planted incident must survive -- typed failure signal outranks position in the ranking",
+  );
+  // A marker missing either field is unrecoverable data loss, not "lossy but recoverable".
+  for (const { $tf_ref } of dropped) {
+    assert.equal(typeof $tf_ref.hash, "string");
+    assert.equal(typeof $tf_ref.namespace, "string");
+  }
+});
+
+test("retrieve round-trips a dropped item, by hash and by text marker", async () => {
+  const { configPath } = throwawayStore();
+  const input = await readFile(INCIDENT_FEED);
+  const lossy = await compress(input, {
+    configPath,
+    format: "json",
+    lossy: "heuristic",
+    lossyRatio: 0.35,
+  });
+  const { $tf_ref: marker } = JSON.parse(Buffer.from(lossy.payload).toString("utf8")).events.find(
+    (event) => event.$tf_ref,
+  );
+
+  const byHash = await retrieve(marker.hash, { configPath, namespace: marker.namespace });
+  const restored = JSON.parse(Buffer.from(byHash).toString("utf8"));
+  const originals = JSON.parse(Buffer.from(input).toString("utf8")).events;
+  assert.deepEqual(
+    originals.find((event) => event.seq === restored.seq),
+    restored,
+    "retrieved bytes must be one of the original, untouched events",
+  );
+
+  // The text-marker form carries its own namespace, so it needs no namespace option.
+  const byMarker = await retrieve(
+    `[tokenfold:retrieve hash=${marker.hash} namespace=${marker.namespace}]`,
+    { configPath },
+  );
+  assert.deepEqual(byMarker, byHash);
+});
+
+test("retrieve rejects an unknown hash, a malformed reference, and a report path", async () => {
+  const { configPath } = throwawayStore();
+  const failsWith = async (reference) => {
+    await assert.rejects(
+      () => retrieve(reference, { configPath }),
+      (error) => {
+        assert.ok(error instanceof TokenFoldProcessError);
+        assert.equal(error.code, "tokenfold_exit");
+        return true;
+      },
+    );
+  };
+  await failsWith("0".repeat(64));
+  await failsWith("not-a-hash");
+  // A CompressionReport carries no per-entry hash, so the CLI refuses it rather than guessing.
+  // retrieve()'s doc comment promises exactly this, so pin it.
+  const { report } = await compress('{"a":1}', { configPath, format: "json" });
+  const reportPath = path.join(path.dirname(configPath), "report.json");
+  writeFileSync(reportPath, JSON.stringify(report));
+  await failsWith(reportPath);
+});
+
+test("lossyPreserve protects a named array, including a top-level one", async () => {
+  const { configPath } = throwawayStore();
+  const options = { configPath, format: "json", lossy: "heuristic", lossyRatio: 0.35 };
+  const feed = await readFile(INCIDENT_FEED);
+  assert.deepEqual(
+    markerHashes((await compress(feed, { ...options, lossyPreserve: ["events"] })).payload),
+    [],
+  );
+
+  // An eligible ROOT array has path "", which the nearest-eligible-ancestor rule once failed to
+  // match at all (cli.rs::lossy_preserve_protects_a_top_level_array). Reuses the feed's own rows,
+  // which are large enough to be worth replacing with a marker, as a bare top-level array; the
+  // nested `users` array is what `lossyPreserve` names from *inside* the eligible root array.
+  const rootArray = JSON.stringify(
+    JSON.parse(Buffer.from(feed).toString("utf8")).events.map((event) => ({
+      ...event,
+      users: [1, 2, 3],
+    })),
+  );
+  assert.ok(
+    markerHashes((await compress(rootArray, options)).payload).length > 0,
+    "control: a root array must be prunable without lossyPreserve",
+  );
+  assert.deepEqual(
+    markerHashes((await compress(rootArray, { ...options, lossyPreserve: ["users"] })).payload),
+    [],
+    "naming a path inside the root array must protect its nearest enclosing eligible array",
+  );
+});
+
+test("a lossy inspect previews json_prune and writes nothing", async () => {
+  const { configPath, storePath } = throwawayStore();
+  const options = { configPath, format: "json", lossy: "heuristic", lossyRatio: 0.35 };
+  const feed = await readFile(INCIDENT_FEED);
+  const preview = await inspect(feed, options);
+
+  assert.deepEqual(
+    preview.payload,
+    Uint8Array.from(feed),
+    "inspect hands the input back unchanged",
+  );
+  assert.ok(
+    preview.report.transforms.some(({ id }) => id === "json_prune"),
+    "a lossy preview must project the json_prune stage, not silently omit it",
+  );
+  assert.ok(preview.report.saved_tokens > 0);
+  assert.throws(() => readdirSync(storePath), "a preview must not create the retrieval store");
+
+  await compress(feed, options);
+  assert.ok(readdirSync(storePath).length > 0, "the real run must still persist");
+});
+
+test("a lossy run that prunes nothing is never worse than the lossless run", async () => {
+  // Identical short rows: nothing here is worth replacing with a marker, but json_field_fold and
+  // json_value_dict have plenty to do -- and lossy defers those rather than disabling them.
+  const { configPath } = throwawayStore();
+  const uniform = JSON.stringify({
+    events: Array.from({ length: 15 }, (_, seq) => ({
+      seq,
+      retries: 0,
+      note: "queue drain cycle completed normally with no backpressure observed",
+    })),
+  });
+  const lossless = await compress(uniform, { configPath, format: "json" });
+  const lossy = await compress(uniform, {
+    configPath,
+    format: "json",
+    lossy: "heuristic",
+    lossyRatio: 0.25,
+  });
+  assert.deepEqual(lossy.payload, lossless.payload);
+});
+
+test("lossy on an unsupported format is a no-op that persists nothing", async () => {
+  const { configPath, storePath } = throwawayStore();
+  const payload = JSON.stringify({
+    model: "gpt-4o",
+    messages: [{ role: "user", content: "summarize the incident feed ".repeat(40) }],
+  });
+  const result = await compress(payload, {
+    configPath,
+    format: "openai",
+    lossy: "heuristic",
+    lossyRatio: 0.35,
+  });
+  // Reported as an explicit skip rather than silently omitted, so the receipt still shows that
+  // lossy was asked for and why it did not run.
+  const prune = result.report.transforms.find(({ id }) => id === "json_prune");
+  assert.equal(prune?.status, "skipped");
+  assert.equal(prune?.skipped_reason, "not_applicable_to_format");
+  assert.ok(!Buffer.from(result.payload).includes("$tf_ref"));
+  // lossy implies a durable receipt only where the lossy stage can actually run.
+  assert.throws(
+    () => readdirSync(storePath),
+    "nothing may persist when the lossy stage cannot run",
+  );
+});
+
+test("lossy options are validated by the CLI and never shell-interpolated", async () => {
+  const { configPath } = throwawayStore();
+  const feed = await readFile(INCIDENT_FEED);
+
+  // lossyRatio without lossy used to be dropped on the floor. The CLI's own `requires = "lossy"`
+  // must surface instead, for compress and for the inspect preview alike.
+  for (const call of [compress, inspect]) {
+    await assert.rejects(
+      () => call(feed, { configPath, format: "json", lossyRatio: 0.35 }),
+      (error) => {
+        assert.equal(error.code, "tokenfold_exit");
+        assert.match(Buffer.from(error.stderr).toString(), /--lossy/);
+        return true;
+      },
+    );
+  }
+
+  // A preserve path is one argv element, never a shell word.
+  const injected = await compress(feed, {
+    configPath,
+    format: "json",
+    lossy: "heuristic",
+    lossyRatio: 0.35,
+    lossyPreserve: ['events" && echo pwned'],
+  });
+  assert.ok(!Buffer.from(injected.payload).includes("pwned"));
+  assert.ok(
+    markerHashes(injected.payload).length > 0,
+    "a bogus preserve path must not protect anything",
+  );
+});
+
+test("a lower lossyRatio keeps fewer items", async () => {
+  const { configPath } = throwawayStore();
+  const feed = await readFile(INCIDENT_FEED);
+  const markerCount = async (lossyRatio) =>
+    markerHashes(
+      (await compress(feed, { configPath, format: "json", lossy: "heuristic", lossyRatio }))
+        .payload,
+    ).length;
+  assert.ok((await markerCount(0.05)) > (await markerCount(0.35)));
 });

--- a/python-tests/test_binding.py
+++ b/python-tests/test_binding.py
@@ -8,6 +8,7 @@ Covers the Python binding's acceptance criteria:
 """
 
 import json
+from pathlib import Path
 
 import pytest
 
@@ -21,6 +22,8 @@ from tokenfold import (
     InputFormat,
     InternalError,
     InvalidInputError,
+    LossyPath,
+    RetrievalError,
     SafetyError,
     Status,
     TokenFoldError,
@@ -29,7 +32,16 @@ from tokenfold import (
     compress_messages,
     compress_openai_payload,
     inspect,
+    retrieve,
 )
+
+# 40 heterogeneous events (different event types carry different fields) plus one planted
+# 503/success:false/retries:7 incident at index 23 -- the same fixture examples/lossy_pruning.py
+# uses. Heterogeneity is deliberate: a uniform array gets folded into columnar form by the
+# lossless pipeline before json_prune ever sees it, which would exercise nothing here.
+INCIDENT_FEED = (
+    Path(__file__).parent.parent / "examples" / "incident_feed.json"
+).read_bytes()
 
 OPENAI_PAYLOAD = json.dumps(
     {
@@ -195,9 +207,12 @@ def test_enum_variant_names_are_all_caps():
     assert Status.BEST_EFFORT is not None
     assert Status.UNREACHABLE_TARGET is not None
 
+    assert LossyPath.HEURISTIC is not None
+
     # No PascalCase leakage.
     assert not hasattr(CompressionMode, "Balanced")
     assert not hasattr(Status, "Compressed")
+    assert not hasattr(LossyPath, "Heuristic")
 
 
 # ---------------------------------------------------------------------------
@@ -207,7 +222,7 @@ def test_enum_variant_names_are_all_caps():
 
 @pytest.mark.parametrize(
     "exc_cls",
-    [InvalidInputError, SafetyError, EstimatorError, ConfigError, InternalError],
+    [InvalidInputError, SafetyError, EstimatorError, ConfigError, InternalError, RetrievalError],
 )
 def test_every_subclass_derives_from_tokenfold_error(exc_cls):
     assert issubclass(exc_cls, TokenFoldError)
@@ -245,6 +260,7 @@ def test_module_exports_the_full_error_hierarchy():
         "EstimatorError",
         "ConfigError",
         "InternalError",
+        "RetrievalError",
     ):
         assert hasattr(tokenfold, name)
 
@@ -272,3 +288,138 @@ def test_inspect_never_writes_to_the_retrieval_store(tmp_path, monkeypatch):
     # assertions above would pass for the wrong reason (nothing being stored under any path).
     compress(OPENAI_PAYLOAD, policy=policy, format=InputFormat.OPENAI_JSON)
     assert any(tmp_path.rglob("*.bin")), "store_originals must still work on a real run"
+
+
+# ---------------------------------------------------------------------------
+# Lossy JSON pruning + retrieve()
+# ---------------------------------------------------------------------------
+
+
+def test_compression_policy_accepts_lossy_settings():
+    policy = CompressionPolicy(
+        lossy=LossyPath.HEURISTIC,
+        lossy_ratio=0.4,
+        lossy_preserve=["events"],
+    )
+    assert policy.lossy == LossyPath.HEURISTIC
+    assert policy.lossy_ratio == 0.4
+    assert policy.lossy_preserve == ["events"]
+
+
+def test_compression_policy_accepts_lossy_as_a_string():
+    policy = CompressionPolicy(lossy="heuristic")
+    assert policy.lossy == LossyPath.HEURISTIC
+
+
+def test_compression_policy_lossy_defaults_to_none():
+    policy = CompressionPolicy()
+    assert policy.lossy is None
+    assert policy.lossy_ratio == 0.3
+    assert policy.lossy_preserve == []
+
+
+def test_lossy_requires_a_durable_retrieval_backend():
+    """Mirrors budget.rs's `lossy_refuses_memory_retrieval_backend`: a lossy run with no
+    durable receipt is real data loss, not "lossy but recoverable" -- CompressionPolicy's own
+    validate() must refuse this from Python exactly like it does from Rust/the CLI."""
+    with pytest.raises(ConfigError):
+        CompressionPolicy(lossy=LossyPath.HEURISTIC, retrieval_backend="memory")
+
+
+def test_lossy_prunes_the_incident_feed_and_the_planted_incident_survives(tmp_path):
+    policy = CompressionPolicy(
+        retrieval_store_path=str(tmp_path),
+        lossy=LossyPath.HEURISTIC,
+        lossy_ratio=0.35,
+    )
+    lossless = compress(INCIDENT_FEED, format=InputFormat.JSON)
+    lossy = compress(INCIDENT_FEED, format=InputFormat.JSON, policy=policy)
+
+    assert lossy.report.saved_tokens > lossless.report.saved_tokens, (
+        "lossy pruning must save strictly more than the lossless pipeline alone on this "
+        "fixture -- if this regresses, the fixture no longer exercises json_prune (see the "
+        "marker-overhead-vs-item-size lesson in the project's own lossy feature notes)"
+    )
+
+    compressed = json.loads(lossy.payload)
+    events = compressed["events"]
+    dropped = [e for e in events if isinstance(e, dict) and "$tf_ref" in e]
+    kept = [e for e in events if isinstance(e, dict) and "$tf_ref" not in e]
+    assert dropped, "this fixture must exercise lossy pruning"
+
+    incident = [e for e in kept if e.get("status_code") == 503]
+    assert incident, (
+        "the planted incident must survive pruning -- structural failure signal outranks "
+        "position in the selection ranking"
+    )
+
+
+def test_retrieve_recovers_a_dropped_event(tmp_path):
+    policy = CompressionPolicy(
+        retrieval_store_path=str(tmp_path),
+        lossy=LossyPath.HEURISTIC,
+        lossy_ratio=0.35,
+    )
+    lossy = compress(INCIDENT_FEED, format=InputFormat.JSON, policy=policy)
+    compressed = json.loads(lossy.payload)
+    dropped = [e for e in compressed["events"] if isinstance(e, dict) and "$tf_ref" in e]
+    assert dropped, "fixture must produce at least one dropped event to retrieve"
+
+    marker = dropped[0]["$tf_ref"]
+    restored = retrieve(marker["hash"], namespace=marker["namespace"], policy=policy)
+
+    original_events = json.loads(INCIDENT_FEED)["events"]
+    assert json.loads(restored) in original_events, (
+        "retrieved bytes must be one of the original, untouched events"
+    )
+
+
+def test_retrieve_via_policy_matches_explicit_kwargs(tmp_path):
+    """`retrieve()`'s `policy=` is sugar for the same namespace/backend/store_path used to
+    compress -- both call shapes must resolve to the same store and the same bytes."""
+    policy = CompressionPolicy(
+        retrieval_store_path=str(tmp_path),
+        lossy=LossyPath.HEURISTIC,
+        lossy_ratio=0.35,
+    )
+    lossy = compress(INCIDENT_FEED, format=InputFormat.JSON, policy=policy)
+    marker = next(
+        e["$tf_ref"]
+        for e in json.loads(lossy.payload)["events"]
+        if isinstance(e, dict) and "$tf_ref" in e
+    )
+
+    via_policy = retrieve(marker["hash"], namespace=marker["namespace"], policy=policy)
+    via_kwargs = retrieve(
+        marker["hash"],
+        namespace=marker["namespace"],
+        backend="filesystem",
+        retrieval_store_path=str(tmp_path),
+    )
+    assert via_policy == via_kwargs
+
+
+def test_retrieve_raises_for_a_missing_hash(tmp_path):
+    with pytest.raises(RetrievalError):
+        retrieve("0" * 64, namespace="default", retrieval_store_path=str(tmp_path))
+
+
+def test_retrieval_error_is_a_tokenfold_error():
+    assert issubclass(RetrievalError, TokenFoldError)
+
+
+def test_inspect_previews_lossy_without_writing_anything(tmp_path):
+    """Same contract as `test_inspect_never_writes_to_the_retrieval_store`, for the lossy path
+    specifically: a preview must never perform a real `RetrievalStore` write, even when it's
+    the lossy stage (not `store_originals`) driving the persistence."""
+    policy = CompressionPolicy(
+        retrieval_store_path=str(tmp_path),
+        lossy=LossyPath.HEURISTIC,
+        lossy_ratio=0.35,
+    )
+    preview = inspect(INCIDENT_FEED, format=InputFormat.JSON, policy=policy)
+    assert preview.payload == INCIDENT_FEED
+    assert not any(tmp_path.rglob("*.bin")), "a lossy preview must not persist anything to disk"
+
+    compress(INCIDENT_FEED, format=InputFormat.JSON, policy=policy)
+    assert any(tmp_path.rglob("*.bin")), "the real run must still persist"

--- a/python-tests/test_binding.py
+++ b/python-tests/test_binding.py
@@ -57,7 +57,7 @@ OPENAI_PAYLOAD = json.dumps(
 
 ANTHROPIC_PAYLOAD = json.dumps(
     {
-        "model": "claude-3-5-sonnet",
+        "model": "claude-sonnet-5",
         "system": "You are a terse assistant. " * 20,
         "messages": [
             {"role": "user", "content": "first question " * 20},


### PR DESCRIPTION
Lossy array-item pruning shipped in 0.4.0 but was reachable only from the CLI.
Both bindings now expose it, with the same fail-closed contract.

## Python

`CompressionPolicy` gains `lossy`, `lossy_ratio`, `lossy_preserve`, and
`retrieval_store_path`; `compress()`/`inspect()` accept the three lossy options
directly. New `retrieve()` restores a dropped item's original bytes, raising the
new `RetrievalError` for a missing or expired hash. New `LossyPath` enum.

## TypeScript

`CompressionOptions` gains `lossy`, `lossyRatio`, `lossyPreserve`; new
`retrieve()` and `LossyPath`. Two details the CLI forces:

- The `inspect` subcommand has no lossy flags, so a lossy `inspect()` routes to
  `compress --dry-run` — the CLI's actual lossy preview, which shares inspect's
  code path and likewise writes the report to stdout with no payload.
- `--lossy-ratio`/`--lossy-preserve` are `requires = "lossy"`, so they are
  forwarded even when `lossy` is unset. Dropping them would silently ignore a
  pruning-aggression knob.

## Docs

The "lossy pruning is CLI-only; Python and TypeScript remain lossless" note was
wrong on every surface and is corrected. Also drops the claim that `tokenfold
retrieve` accepts a CompressionReport path — `cmd_retrieve` deliberately rejects
one, since `RetrievalReport` carries no per-entry content hash.

## Tests

- Python: 34 pass, covering policy validation, pruning, preserve, retrieve, and
  the no-write preview.
- Node: 22 tests (21 pass, 1 skipped as platform-specific), porting the
  regressions the CLI suite already pins — the planted incident survives
  ranking, `lossyPreserve` protects a top-level array whose path is `""`, a
  prune-nothing run is never worse than lossless, and lossy on an unsupported
  format persists nothing.
- Rust: unchanged; `cargo fmt --check` and `clippy -D warnings` clean.

No public Rust API change: `tokenfold-core`'s only diff is an `[[example]]`
declaration, which `cargo publish --dry-run` skips with a warning.
