### PR TITLE
release: prepare v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [0.4.1] - 2026-08-18
 
 - **Python: opt-in lossy JSON pruning is now reachable from the binding**, previously
   CLI-only. `CompressionPolicy` gained `lossy`, `lossy_ratio`, `lossy_preserve`, and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1013,7 +1013,7 @@ dependencies = [
 
 [[package]]
 name = "tokenfold-adapters"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -1022,7 +1022,7 @@ dependencies = [
 
 [[package]]
 name = "tokenfold-admin"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "ed25519-dalek",
  "serde",
@@ -1032,7 +1032,7 @@ dependencies = [
 
 [[package]]
 name = "tokenfold-cli"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "clap",
  "serde",
@@ -1045,7 +1045,7 @@ dependencies = [
 
 [[package]]
 name = "tokenfold-core"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "proptest",
  "regex",
@@ -1059,25 +1059,25 @@ dependencies = [
 
 [[package]]
 name = "tokenfold-image"
-version = "0.4.0"
+version = "0.4.1"
 
 [[package]]
 name = "tokenfold-learn"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "tokenfold-core",
 ]
 
 [[package]]
 name = "tokenfold-output"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "tokenfold-core",
 ]
 
 [[package]]
 name = "tokenfold-proxy"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "clap",
  "serde",
@@ -1089,7 +1089,7 @@ dependencies = [
 
 [[package]]
 name = "tokenfold-py"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "pyo3",
  "serde_json",
@@ -1098,7 +1098,7 @@ dependencies = [
 
 [[package]]
 name = "tokenfold-rag"
-version = "0.4.0"
+version = "0.4.1"
 
 [[package]]
 name = "toml"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 rust-version = "1.97"
 license = "Apache-2.0"

--- a/crates/tokenfold-cli/Cargo.toml
+++ b/crates/tokenfold-cli/Cargo.toml
@@ -14,9 +14,9 @@ name = "tokenfold"
 path = "src/main.rs"
 
 [dependencies]
-tokenfold-core = { version = "0.4.0", path = "../tokenfold-core" }
-tokenfold-output = { version = "0.4.0", path = "../tokenfold-output" }
-tokenfold-learn = { version = "0.4.0", path = "../tokenfold-learn" }
+tokenfold-core = { version = "0.4.1", path = "../tokenfold-core" }
+tokenfold-output = { version = "0.4.1", path = "../tokenfold-output" }
+tokenfold-learn = { version = "0.4.1", path = "../tokenfold-learn" }
 clap = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/tokenfold-learn/Cargo.toml
+++ b/crates/tokenfold-learn/Cargo.toml
@@ -10,4 +10,4 @@ keywords = ["llm", "tokens", "compression", "policy", "token-optimization"]
 categories = ["compression"]
 
 [dependencies]
-tokenfold-core = { version = "0.4.0", path = "../tokenfold-core" }
+tokenfold-core = { version = "0.4.1", path = "../tokenfold-core" }

--- a/crates/tokenfold-output/Cargo.toml
+++ b/crates/tokenfold-output/Cargo.toml
@@ -10,4 +10,4 @@ keywords = ["llm", "tokens", "compression", "reports", "token-optimization"]
 categories = ["compression"]
 
 [dependencies]
-tokenfold-core = { version = "0.4.0", path = "../tokenfold-core" }
+tokenfold-core = { version = "0.4.1", path = "../tokenfold-core" }

--- a/crates/tokenfold-py/Cargo.toml
+++ b/crates/tokenfold-py/Cargo.toml
@@ -16,7 +16,7 @@ name = "tokenfold_py"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-tokenfold-core = { version = "0.4.0", path = "../tokenfold-core" }
+tokenfold-core = { version = "0.4.1", path = "../tokenfold-core" }
 serde_json = { workspace = true }
 pyo3 = { version = "0.29.0", features = ["abi3-py39"] }
 

--- a/packages/tokenfold/package-lock.json
+++ b/packages/tokenfold/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tokenfold",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tokenfold",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "Apache-2.0",
       "bin": {
         "tokenfold": "bin/tokenfold.js"
@@ -19,92 +19,27 @@
         "node": ">=22"
       },
       "optionalDependencies": {
-        "@tokenfold/cli-darwin-arm64": "0.4.0",
-        "@tokenfold/cli-darwin-x64": "0.4.0",
-        "@tokenfold/cli-linux-arm64": "0.4.0",
-        "@tokenfold/cli-linux-x64": "0.4.0",
-        "@tokenfold/cli-win32-x64": "0.4.0"
+        "@tokenfold/cli-darwin-arm64": "0.4.1",
+        "@tokenfold/cli-darwin-x64": "0.4.1",
+        "@tokenfold/cli-linux-arm64": "0.4.1",
+        "@tokenfold/cli-linux-x64": "0.4.1",
+        "@tokenfold/cli-win32-x64": "0.4.1"
       }
     },
     "node_modules/@tokenfold/cli-darwin-arm64": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@tokenfold/cli-darwin-arm64/-/cli-darwin-arm64-0.4.0.tgz",
-      "integrity": "sha512-W4Ky2rWLllYxZXZNp3FFb/CpNhloFhT4nM4F9ZjyiZye7Cc+MK4tWYjO/xfGm+c6L0m7t+iZqmkj/TsReQoIEg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=22"
-      }
+      "optional": true
     },
     "node_modules/@tokenfold/cli-darwin-x64": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@tokenfold/cli-darwin-x64/-/cli-darwin-x64-0.4.0.tgz",
-      "integrity": "sha512-HarLvXGLChGuN4JgfNAqVR+bUoPWevonMOf5sS1ntszFa20KSr5o+U0+YdW1irexVk2jftK90N6cLkPTTJMilA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=22"
-      }
+      "optional": true
     },
     "node_modules/@tokenfold/cli-linux-arm64": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@tokenfold/cli-linux-arm64/-/cli-linux-arm64-0.4.0.tgz",
-      "integrity": "sha512-2jNDdvMP3NPCVvyUExIV02WR1Q9V08S6uI6RfWLWM6rPYgJfe5rkjJsbmUgqYLYUUWZI7AYCtY2tfBP/JqkVcA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=22"
-      }
+      "optional": true
     },
     "node_modules/@tokenfold/cli-linux-x64": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@tokenfold/cli-linux-x64/-/cli-linux-x64-0.4.0.tgz",
-      "integrity": "sha512-hr4lqubP0mcWOfkwQqrP5qVD4nZ9JnjCv+bTmGBpMI3EYZkWnADNlXzSnr+VXQVrNBRnLuu/WZiN8cFlcSJzsg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=22"
-      }
+      "optional": true
     },
     "node_modules/@tokenfold/cli-win32-x64": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@tokenfold/cli-win32-x64/-/cli-win32-x64-0.4.0.tgz",
-      "integrity": "sha512-b2FfC2KTT+Qp9DM9pdJhBhyMCLD4fvy2RvVtu5YEXiZIoT+0AbS/TIsnb0aye9MZX8nsep2vJ+DuK89herlTeg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=22"
-      }
+      "optional": true
     },
     "node_modules/@types/node": {
       "version": "24.13.3",

--- a/packages/tokenfold/package.json
+++ b/packages/tokenfold/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokenfold",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Token-aware compression for LLM payloads, backed by the tokenfold Rust CLI.",
   "license": "Apache-2.0",
   "repository": {
@@ -49,11 +49,11 @@
     "prepack": "npm run build"
   },
   "optionalDependencies": {
-    "@tokenfold/cli-darwin-x64": "0.4.0",
-    "@tokenfold/cli-darwin-arm64": "0.4.0",
-    "@tokenfold/cli-linux-x64": "0.4.0",
-    "@tokenfold/cli-linux-arm64": "0.4.0",
-    "@tokenfold/cli-win32-x64": "0.4.0"
+    "@tokenfold/cli-darwin-x64": "0.4.1",
+    "@tokenfold/cli-darwin-arm64": "0.4.1",
+    "@tokenfold/cli-linux-x64": "0.4.1",
+    "@tokenfold/cli-linux-arm64": "0.4.1",
+    "@tokenfold/cli-win32-x64": "0.4.1"
   },
   "devDependencies": {
     "@types/node": "^24.0.0",

--- a/packages/tokenfold/test/api.test.mjs
+++ b/packages/tokenfold/test/api.test.mjs
@@ -14,7 +14,7 @@ import {
 } from "../dist/index.js";
 
 const testBinary = process.env.TOKENFOLD_TEST_BINARY;
-if (!testBinary) throw new Error("TOKENFOLD_TEST_BINARY must point to a tokenfold 0.4.0 binary");
+if (!testBinary) throw new Error("TOKENFOLD_TEST_BINARY must point to a tokenfold 0.4.1 binary");
 process.env.TOKENFOLD_BINARY_PATH = testBinary;
 
 // A heterogeneous incident feed: lossless folding has a ceiling on it, so lossy pruning
@@ -56,7 +56,7 @@ test("resolves an explicit binary and reports its version", async () => {
   assert.equal(binaryPath(), testBinary);
   const result = await run(["--version"]);
   assert.equal(result.exitCode, 0);
-  assert.match(Buffer.from(result.stdout).toString(), /^tokenfold 0\.4\.0/);
+  assert.match(Buffer.from(result.stdout).toString(), /^tokenfold 0\.4\.1/);
 });
 
 test("compress returns bytes and a canonical report", async () => {

--- a/scripts/stage-npm-platform-packages.test.mjs
+++ b/scripts/stage-npm-platform-packages.test.mjs
@@ -33,7 +33,7 @@ async function fixture() {
 test("stages five exact-version platform packages with verified checksums", async () => {
   const { assets, directory, output } = await fixture();
   try {
-    execFileSync(process.execPath, [script, "0.4.0", assets, output], { cwd: root });
+    execFileSync(process.execPath, [script, "0.4.1", assets, output], { cwd: root });
     const packages = [
       "cli-darwin-x64",
       "cli-darwin-arm64",
@@ -43,7 +43,7 @@ test("stages five exact-version platform packages with verified checksums", asyn
     ];
     for (const packageDirectory of packages) {
       const manifest = JSON.parse(await readFile(join(output, packageDirectory, "package.json")));
-      assert.equal(manifest.version, "0.4.0");
+      assert.equal(manifest.version, "0.4.1");
       assert.equal(manifest.publishConfig.provenance, true);
     }
     if (process.platform !== "win32") {
@@ -60,7 +60,7 @@ test("rejects a mismatched platform checksum", async () => {
   try {
     await writeFile(join(assets, `${assetNames[0]}.sha256`), `${"0".repeat(64)}  bad\n`);
     assert.throws(
-      () => execFileSync(process.execPath, [script, "0.4.0", assets, output], {
+      () => execFileSync(process.execPath, [script, "0.4.1", assets, output], {
         cwd: root,
         stdio: "pipe",
       }),


### PR DESCRIPTION
Version bump only — no behavior change. The 0.4.1 content landed in #13.

Patch rather than minor: the change set is additive to the Python and
TypeScript bindings and leaves the public Rust API untouched, so nothing
depending on `tokenfold-core = "0.4"` breaks. `tokenfold-core`'s only diff
since 0.4.0 is an `[[example]]` declaration pointing out of the crate root,
which `cargo publish` skips with a warning — verified with
`cargo publish -p tokenfold-core --dry-run --locked` at the new version.

Bumped:

- `Cargo.toml` `[workspace.package]` version and the inter-crate dependency
  pins in `tokenfold-cli`, `tokenfold-learn`, `tokenfold-output`, `tokenfold-py`
- `Cargo.lock` (`cargo update -w`) and `packages/tokenfold/package-lock.json`
  (`npm install --package-lock-only`)
- `packages/tokenfold/package.json` version + all five `optionalDependencies`
- Version assertions in `packages/tokenfold/test/api.test.mjs` — both the plain
  string and the regex-escaped `/^tokenfold 0\.4\.1/` — and in
  `scripts/stage-npm-platform-packages.test.mjs`
- `CHANGELOG.md`: `[Unreleased]` → `[0.4.1] - 2026-08-18`

Deliberately untouched: `eval/tasks/v04/*.json`, which contains `0.4.0-alpha`
inside synthetic build-error fixture text, and the `rtk 0.4.1` pins in
`crates/tokenfold-cli/{src,tests}/rtk.rs`, which are a third-party tool's
version. A repo-wide find-and-replace would have corrupted both.

Verified locally: `cargo fmt --check`, `clippy -D warnings`, the rebuilt CLI
reports `tokenfold 0.4.1`, and the npm suite passes against it (21 pass,
1 skipped).
