### PR TITLE
docs: re-measure README claims on regenerated fixtures, pin them with tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 # Agent / editor configuration, machine-local by nature.
 .claude/*
 /.codex/
+/.vscode/
 /CLAUDE.local.md
 
 # Working design documents. Tracked source must not reference these -- a clone

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,132 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances
+  of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+koduri.saisachin95@gmail.com. All complaints will be reviewed and investigated
+promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/inclusion
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,8 @@
 # Contributing
 
+Participation in this project is governed by the
+[Code of Conduct](CODE_OF_CONDUCT.md).
+
 ## Branch model
 
 `main` is the only long-lived branch. It is protected: no direct pushes, no

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ CLI · Python · TypeScript · Rust · proxy · MCP · local-first · provider-n
 
 | Search / RAG results | Repetitive JSON | API responses | Tool schemas |
 | :---: | :---: | :---: | :---: |
-| **91.7% fewer tokens** | **67.6% fewer tokens** | **61.3% fewer tokens** | **45.6% fewer tokens** |
+| **91.7% fewer tokens** | **67.6% fewer tokens** | **63.9% fewer tokens** | **45.6% fewer tokens** |
 | 84,032 → 6,951 | 50-record payload | 30-record payload | 1.8 MB OpenAI fixture |
 | opt-in, recoverable | lossless | lossless | lossless |
 
@@ -68,7 +68,7 @@ gold answer survived selection under the stated budget.
 | --- | --- | --- |
 | **What it does** | Minifies, folds repeated keys into columns, and stores repeated values once | Adds deterministic ranking and retrieval markers for selected array rows |
 | **Best on** | Uniform records, schemas, logs, diffs | Search results, mixed event feeds, agent traces, long arrays |
-| **Measured here** | **45.6–67.6%** fewer tokens | **39.3–91.7%** fewer tokens |
+| **Measured here** | **45.6–67.6%** fewer tokens | **51.7–91.7%** fewer tokens |
 | **Recovery** | All data remains in the payload | Every emitted marker resolves through the local retrieval store |
 
 ## Quick start
@@ -131,8 +131,9 @@ cargo run -p tokenfold-core --example quickstart   # Rust: the embedded core API
 python examples/lossy_pruning.py   # CLI: opt-in recoverable pruning, end to end
 ```
 
-[`examples/quickstart.ipynb`](examples/quickstart.ipynb) is the notebook form of the
-Python quickstart, one operation per cell.
+[`examples/quickstart.ipynb`](examples/quickstart.ipynb) is the guided tour of the whole
+Python surface: everything `quickstart.py` shows, plus previews, budgets and modes,
+provider payloads, recoverable pruning with retrieval, and where Tokenfold Select fits.
 
 ## Recoverable lossy pruning
 
@@ -150,18 +151,19 @@ On the bundled 40-event feed:
 
 | Mode | Exact tokens | Reduction | Events kept | Incident kept |
 | --- | ---: | ---: | ---: | :---: |
-| Lossless | 2,840 | 28.1% | 40 | ✅ |
-| `--lossy-ratio 0.35` | 2,399 | **39.3%** | 13 | ✅ |
-| `--lossy-ratio 0.05` | 2,192 | **44.5%** | 2 | ✅ |
+| Lossless | 6,144 | 14.9% | 40 | ✅ |
+| `--lossy-ratio 0.35` | 3,485 | **51.7%** | 13 | ✅ |
+| `--lossy-ratio 0.05` | 2,294 | **68.2%** | 1 | ✅ |
 
 The planted `503` with `success: false` and `retries: 7` survives every shown
-setting because typed failure signals outrank position and length. Long rows
+setting because typed failure signals outrank position and length — at
+`--lossy-ratio 0.05` it is the only row kept. Long rows
 amortize marker overhead further: the 100-result showcase reaches **91.7%**.
 
 Fetch a dropped row:
 
 ```bash
-tokenfold retrieve 978339a8898fedde3c5b0662a213f12ae4ad1b7fe6771f62b3c3d74d87389a4c
+tokenfold retrieve cb13cc59cca0c218c579cd1d4b3cbab58d6dea265eb995cc9c00faf0cd0a6856
 # {"seq":1,"ts":"2026-08-15T00:01:11Z","subsystem":"index-writer",...}
 ```
 
@@ -310,8 +312,8 @@ cargo run --release --locked -p tokenfold-cli -- \
   inspect examples/api_response.json --format json
 ```
 
-The small bundled API response reports 382 → 206 tokens, a **46.1% lossless
-reduction**. Benchmark sources and thresholds live in [CHANGELOG.md](https://github.com/snchimata/tokenfold/blob/main/CHANGELOG.md)
+The bundled 30-record API response reports 3,812 → 1,376 tokens, a **63.9%
+lossless reduction**. Benchmark sources and thresholds live in [CHANGELOG.md](https://github.com/snchimata/tokenfold/blob/main/CHANGELOG.md)
 and [`crates/tokenfold-core/benches/THRESHOLDS.toml`](https://github.com/snchimata/tokenfold/blob/main/crates/tokenfold-core/benches/THRESHOLDS.toml).
 
 ## Contributing

--- a/examples/api_response.json
+++ b/examples/api_response.json
@@ -1,13 +1,588 @@
 {
   "status": "ok",
   "page": 1,
-  "total": 6,
+  "per_page": 30,
+  "total": 30,
   "results": [
-    { "id": 1001, "name": "Ada Lovelace",   "role": "admin",  "active": true,  "plan": { "tier": "pro",  "seats": 5, "region": "us-east-1" } },
-    { "id": 1002, "name": "Alan Turing",     "role": "member", "active": true,  "plan": { "tier": "pro",  "seats": 5, "region": "us-east-1" } },
-    { "id": 1003, "name": "Grace Hopper",    "role": "member", "active": false, "plan": { "tier": "pro",  "seats": 5, "region": "us-east-1" } },
-    { "id": 1004, "name": "Katherine Johnson","role": "member","active": true,  "plan": { "tier": "free", "seats": 1, "region": "us-east-1" } },
-    { "id": 1005, "name": "Edsger Dijkstra", "role": "member", "active": true,  "plan": { "tier": "free", "seats": 1, "region": "us-east-1" } },
-    { "id": 1006, "name": "Barbara Liskov",  "role": "admin",  "active": true,  "plan": { "tier": "pro",  "seats": 5, "region": "us-east-1" } }
+    {
+      "id": 1001,
+      "name": "Ada Lovelace",
+      "role": "admin",
+      "active": true,
+      "email_verified": true,
+      "last_login": "2026-08-01T09:00:00Z",
+      "plan": {
+        "tier": "pro",
+        "seats": 5,
+        "region": "us-east-1",
+        "billing_cycle": "annual",
+        "support_level": "priority"
+      },
+      "permissions": [
+        "read",
+        "write",
+        "billing",
+        "admin"
+      ]
+    },
+    {
+      "id": 1002,
+      "name": "Alan Turing",
+      "role": "member",
+      "active": true,
+      "email_verified": true,
+      "last_login": "2026-08-02T09:01:00Z",
+      "plan": {
+        "tier": "free",
+        "seats": 1,
+        "region": "us-east-1",
+        "billing_cycle": "monthly",
+        "support_level": "community"
+      },
+      "permissions": [
+        "read",
+        "write"
+      ]
+    },
+    {
+      "id": 1003,
+      "name": "Grace Hopper",
+      "role": "member",
+      "active": true,
+      "email_verified": true,
+      "last_login": "2026-08-03T09:02:00Z",
+      "plan": {
+        "tier": "team",
+        "seats": 25,
+        "region": "eu-west-1",
+        "billing_cycle": "annual",
+        "support_level": "priority"
+      },
+      "permissions": [
+        "read",
+        "write"
+      ]
+    },
+    {
+      "id": 1004,
+      "name": "Katherine Johnson",
+      "role": "member",
+      "active": false,
+      "email_verified": true,
+      "last_login": "2026-08-04T09:03:00Z",
+      "plan": {
+        "tier": "pro",
+        "seats": 5,
+        "region": "us-east-1",
+        "billing_cycle": "annual",
+        "support_level": "priority"
+      },
+      "permissions": [
+        "read",
+        "write"
+      ]
+    },
+    {
+      "id": 1005,
+      "name": "Edsger Dijkstra",
+      "role": "member",
+      "active": true,
+      "email_verified": true,
+      "last_login": "2026-08-05T09:04:00Z",
+      "plan": {
+        "tier": "free",
+        "seats": 1,
+        "region": "us-east-1",
+        "billing_cycle": "monthly",
+        "support_level": "community"
+      },
+      "permissions": [
+        "read",
+        "write"
+      ]
+    },
+    {
+      "id": 1006,
+      "name": "Barbara Liskov",
+      "role": "member",
+      "active": true,
+      "email_verified": true,
+      "last_login": "2026-08-06T09:05:00Z",
+      "plan": {
+        "tier": "pro",
+        "seats": 5,
+        "region": "us-east-1",
+        "billing_cycle": "annual",
+        "support_level": "priority"
+      },
+      "permissions": [
+        "read",
+        "write"
+      ]
+    },
+    {
+      "id": 1007,
+      "name": "Donald Knuth",
+      "role": "member",
+      "active": true,
+      "email_verified": true,
+      "last_login": "2026-08-07T09:06:00Z",
+      "plan": {
+        "tier": "pro",
+        "seats": 5,
+        "region": "us-east-1",
+        "billing_cycle": "annual",
+        "support_level": "priority"
+      },
+      "permissions": [
+        "read",
+        "write"
+      ]
+    },
+    {
+      "id": 1008,
+      "name": "Radia Perlman",
+      "role": "admin",
+      "active": true,
+      "email_verified": true,
+      "last_login": "2026-08-08T09:07:00Z",
+      "plan": {
+        "tier": "free",
+        "seats": 1,
+        "region": "us-east-1",
+        "billing_cycle": "monthly",
+        "support_level": "community"
+      },
+      "permissions": [
+        "read",
+        "write",
+        "billing",
+        "admin"
+      ]
+    },
+    {
+      "id": 1009,
+      "name": "John Backus",
+      "role": "member",
+      "active": true,
+      "email_verified": true,
+      "last_login": "2026-08-09T09:08:00Z",
+      "plan": {
+        "tier": "team",
+        "seats": 25,
+        "region": "eu-west-1",
+        "billing_cycle": "annual",
+        "support_level": "priority"
+      },
+      "permissions": [
+        "read",
+        "write"
+      ]
+    },
+    {
+      "id": 1010,
+      "name": "Frances Allen",
+      "role": "member",
+      "active": false,
+      "email_verified": true,
+      "last_login": "2026-08-10T09:09:00Z",
+      "plan": {
+        "tier": "pro",
+        "seats": 5,
+        "region": "us-east-1",
+        "billing_cycle": "annual",
+        "support_level": "priority"
+      },
+      "permissions": [
+        "read",
+        "write"
+      ]
+    },
+    {
+      "id": 1011,
+      "name": "Ken Thompson",
+      "role": "member",
+      "active": true,
+      "email_verified": true,
+      "last_login": "2026-08-11T09:10:00Z",
+      "plan": {
+        "tier": "pro",
+        "seats": 5,
+        "region": "us-east-1",
+        "billing_cycle": "annual",
+        "support_level": "priority"
+      },
+      "permissions": [
+        "read",
+        "write"
+      ]
+    },
+    {
+      "id": 1012,
+      "name": "Adele Goldberg",
+      "role": "member",
+      "active": true,
+      "email_verified": true,
+      "last_login": "2026-08-12T09:11:00Z",
+      "plan": {
+        "tier": "team",
+        "seats": 25,
+        "region": "eu-west-1",
+        "billing_cycle": "annual",
+        "support_level": "priority"
+      },
+      "permissions": [
+        "read",
+        "write"
+      ]
+    },
+    {
+      "id": 1013,
+      "name": "Dennis Ritchie",
+      "role": "member",
+      "active": true,
+      "email_verified": true,
+      "last_login": "2026-08-13T09:12:00Z",
+      "plan": {
+        "tier": "pro",
+        "seats": 5,
+        "region": "us-east-1",
+        "billing_cycle": "annual",
+        "support_level": "priority"
+      },
+      "permissions": [
+        "read",
+        "write"
+      ]
+    },
+    {
+      "id": 1014,
+      "name": "Margaret Hamilton",
+      "role": "member",
+      "active": true,
+      "email_verified": true,
+      "last_login": "2026-08-14T09:13:00Z",
+      "plan": {
+        "tier": "free",
+        "seats": 1,
+        "region": "us-east-1",
+        "billing_cycle": "monthly",
+        "support_level": "community"
+      },
+      "permissions": [
+        "read",
+        "write"
+      ]
+    },
+    {
+      "id": 1015,
+      "name": "Tony Hoare",
+      "role": "admin",
+      "active": true,
+      "email_verified": true,
+      "last_login": "2026-08-15T09:14:00Z",
+      "plan": {
+        "tier": "team",
+        "seats": 25,
+        "region": "eu-west-1",
+        "billing_cycle": "annual",
+        "support_level": "priority"
+      },
+      "permissions": [
+        "read",
+        "write",
+        "billing",
+        "admin"
+      ]
+    },
+    {
+      "id": 1016,
+      "name": "Lynn Conway",
+      "role": "member",
+      "active": false,
+      "email_verified": true,
+      "last_login": "2026-08-16T09:15:00Z",
+      "plan": {
+        "tier": "pro",
+        "seats": 5,
+        "region": "us-east-1",
+        "billing_cycle": "annual",
+        "support_level": "priority"
+      },
+      "permissions": [
+        "read",
+        "write"
+      ]
+    },
+    {
+      "id": 1017,
+      "name": "Niklaus Wirth",
+      "role": "member",
+      "active": true,
+      "email_verified": true,
+      "last_login": "2026-08-17T09:16:00Z",
+      "plan": {
+        "tier": "free",
+        "seats": 1,
+        "region": "us-east-1",
+        "billing_cycle": "monthly",
+        "support_level": "community"
+      },
+      "permissions": [
+        "read",
+        "write"
+      ]
+    },
+    {
+      "id": 1018,
+      "name": "Shafi Goldwasser",
+      "role": "member",
+      "active": true,
+      "email_verified": true,
+      "last_login": "2026-08-18T09:17:00Z",
+      "plan": {
+        "tier": "team",
+        "seats": 25,
+        "region": "eu-west-1",
+        "billing_cycle": "annual",
+        "support_level": "priority"
+      },
+      "permissions": [
+        "read",
+        "write"
+      ]
+    },
+    {
+      "id": 1019,
+      "name": "Leslie Lamport",
+      "role": "member",
+      "active": true,
+      "email_verified": true,
+      "last_login": "2026-08-19T09:18:00Z",
+      "plan": {
+        "tier": "pro",
+        "seats": 5,
+        "region": "us-east-1",
+        "billing_cycle": "annual",
+        "support_level": "priority"
+      },
+      "permissions": [
+        "read",
+        "write"
+      ]
+    },
+    {
+      "id": 1020,
+      "name": "Anita Borg",
+      "role": "member",
+      "active": true,
+      "email_verified": true,
+      "last_login": "2026-08-20T09:19:00Z",
+      "plan": {
+        "tier": "free",
+        "seats": 1,
+        "region": "us-east-1",
+        "billing_cycle": "monthly",
+        "support_level": "community"
+      },
+      "permissions": [
+        "read",
+        "write"
+      ]
+    },
+    {
+      "id": 1021,
+      "name": "John McCarthy",
+      "role": "member",
+      "active": true,
+      "email_verified": true,
+      "last_login": "2026-08-21T09:20:00Z",
+      "plan": {
+        "tier": "pro",
+        "seats": 5,
+        "region": "us-east-1",
+        "billing_cycle": "annual",
+        "support_level": "priority"
+      },
+      "permissions": [
+        "read",
+        "write"
+      ]
+    },
+    {
+      "id": 1022,
+      "name": "Karen Sparck Jones",
+      "role": "admin",
+      "active": false,
+      "email_verified": true,
+      "last_login": "2026-08-22T09:21:00Z",
+      "plan": {
+        "tier": "pro",
+        "seats": 5,
+        "region": "us-east-1",
+        "billing_cycle": "annual",
+        "support_level": "priority"
+      },
+      "permissions": [
+        "read",
+        "write",
+        "billing",
+        "admin"
+      ]
+    },
+    {
+      "id": 1023,
+      "name": "Claude Shannon",
+      "role": "member",
+      "active": true,
+      "email_verified": true,
+      "last_login": "2026-08-23T09:22:00Z",
+      "plan": {
+        "tier": "free",
+        "seats": 1,
+        "region": "us-east-1",
+        "billing_cycle": "monthly",
+        "support_level": "community"
+      },
+      "permissions": [
+        "read",
+        "write"
+      ]
+    },
+    {
+      "id": 1024,
+      "name": "Jean Bartik",
+      "role": "member",
+      "active": true,
+      "email_verified": true,
+      "last_login": "2026-08-24T09:23:00Z",
+      "plan": {
+        "tier": "team",
+        "seats": 25,
+        "region": "eu-west-1",
+        "billing_cycle": "annual",
+        "support_level": "priority"
+      },
+      "permissions": [
+        "read",
+        "write"
+      ]
+    },
+    {
+      "id": 1025,
+      "name": "Vint Cerf",
+      "role": "member",
+      "active": true,
+      "email_verified": true,
+      "last_login": "2026-08-25T09:24:00Z",
+      "plan": {
+        "tier": "pro",
+        "seats": 5,
+        "region": "us-east-1",
+        "billing_cycle": "annual",
+        "support_level": "priority"
+      },
+      "permissions": [
+        "read",
+        "write"
+      ]
+    },
+    {
+      "id": 1026,
+      "name": "Sophie Wilson",
+      "role": "member",
+      "active": true,
+      "email_verified": true,
+      "last_login": "2026-08-26T09:25:00Z",
+      "plan": {
+        "tier": "pro",
+        "seats": 5,
+        "region": "us-east-1",
+        "billing_cycle": "annual",
+        "support_level": "priority"
+      },
+      "permissions": [
+        "read",
+        "write"
+      ]
+    },
+    {
+      "id": 1027,
+      "name": "Bjarne Stroustrup",
+      "role": "member",
+      "active": true,
+      "email_verified": true,
+      "last_login": "2026-08-27T09:26:00Z",
+      "plan": {
+        "tier": "team",
+        "seats": 25,
+        "region": "eu-west-1",
+        "billing_cycle": "annual",
+        "support_level": "priority"
+      },
+      "permissions": [
+        "read",
+        "write"
+      ]
+    },
+    {
+      "id": 1028,
+      "name": "Gladys West",
+      "role": "member",
+      "active": false,
+      "email_verified": true,
+      "last_login": "2026-08-28T09:27:00Z",
+      "plan": {
+        "tier": "pro",
+        "seats": 5,
+        "region": "us-east-1",
+        "billing_cycle": "annual",
+        "support_level": "priority"
+      },
+      "permissions": [
+        "read",
+        "write"
+      ]
+    },
+    {
+      "id": 1029,
+      "name": "Guido van Rossum",
+      "role": "admin",
+      "active": true,
+      "email_verified": true,
+      "last_login": "2026-08-01T09:28:00Z",
+      "plan": {
+        "tier": "free",
+        "seats": 1,
+        "region": "us-east-1",
+        "billing_cycle": "monthly",
+        "support_level": "community"
+      },
+      "permissions": [
+        "read",
+        "write",
+        "billing",
+        "admin"
+      ]
+    },
+    {
+      "id": 1030,
+      "name": "Hedy Lamarr",
+      "role": "member",
+      "active": true,
+      "email_verified": true,
+      "last_login": "2026-08-02T09:29:00Z",
+      "plan": {
+        "tier": "team",
+        "seats": 25,
+        "region": "eu-west-1",
+        "billing_cycle": "annual",
+        "support_level": "priority"
+      },
+      "permissions": [
+        "read",
+        "write"
+      ]
+    }
   ]
 }

--- a/examples/incident_feed.json
+++ b/examples/incident_feed.json
@@ -11,7 +11,7 @@
       "status_code": 200,
       "duration_ms": 90,
       "bytes_out": 1200,
-      "detail": "ingest-gateway completed its scheduled reconciliation pass and reported no drift against the desired state"
+      "detail": "ingest-gateway handled GET /v2/ingest-gateway/status in 90 ms and returned HTTP 200 with 1200 bytes in the response body. The request was served from the warm path with no upstream fan-out; connection reuse was confirmed and the keep-alive pool stayed at its steady-state size. Downstream callers saw p99 latency inside the objective for the interval, and the request completed under trace id req-7100-inge with no retries, no queue spill, and no degradation flags raised by the admission controller."
     },
     {
       "seq": 1,
@@ -20,7 +20,7 @@
       "event": "cache",
       "hit_ratio": 0.91,
       "evictions": 1,
-      "detail": "index-writer observed replication lag well inside the configured tolerance for the whole interval"
+      "detail": "index-writer reported a cache hit ratio of 0.91 over the sampling window with 1 eviction(s), all age-based and none under memory pressure. The working set stayed resident, the shard-local LRU segments rotated on schedule, and refill traffic to the backing store remained inside the provisioned budget. Prefetch effectiveness held steady and the negative-lookup cache absorbed the usual crawler burst around cycle 1; no keys were invalidated out of band and no coherence warnings were emitted."
     },
     {
       "seq": 2,
@@ -30,7 +30,7 @@
       "lag_ms": 66,
       "success": true,
       "peer": "shard-router-replica-2",
-      "detail": "shard-router re-registered with service discovery after the routine deploy and passed every readiness probe"
+      "detail": "shard-router completed its replication round against shard-router-replica-2 with 66 ms of measured lag, success=true, and a clean acknowledgement from the follower quorum. The write-ahead segment shipped in one batch, checksum verification matched on both ends, and the follower applied the delta without reordering or gap detection. Watermarks advanced normally under epoch 42; no snapshot fallback was required and the catch-up queue drained back to empty before the next scheduling tick."
     },
     {
       "seq": 3,
@@ -40,7 +40,7 @@
       "task": "segment_compaction",
       "reclaimed_mb": 155,
       "retries": 0,
-      "detail": "cache-tier rotated its short-lived credentials and re-established upstream sessions without interruption"
+      "detail": "cache-tier finished scheduled task 'segment_compaction' and reclaimed 155 MB with 0 retry(ies). The pass ran inside its maintenance window with throttling engaged, held the IO ceiling for the whole run, and released its lease cleanly at the end. Tombstone counts, segment fragmentation, and index bloat all landed inside their post-task targets for cycle 3; the follow-up verification sweep found no orphaned references and scheduled nothing for the remediation queue."
     },
     {
       "seq": 4,
@@ -51,7 +51,7 @@
       "status_code": 200,
       "duration_ms": 118,
       "bytes_out": 1324,
-      "detail": "replica-sync observed replication lag well inside the configured tolerance for the whole interval"
+      "detail": "replica-sync handled GET /v2/replica-sync/status in 118 ms and returned HTTP 200 with 1324 bytes in the response body. The request was served from the warm path with no upstream fan-out; connection reuse was confirmed and the keep-alive pool stayed at its steady-state size. Downstream callers saw p99 latency inside the objective for the interval, and the request completed under trace id req-7152-repl with no retries, no queue spill, and no degradation flags raised by the admission controller."
     },
     {
       "seq": 5,
@@ -60,7 +60,7 @@
       "event": "cache",
       "hit_ratio": 0.95,
       "evictions": 0,
-      "detail": "auth-broker completed its scheduled reconciliation pass and reported no drift against the desired state"
+      "detail": "auth-broker reported a cache hit ratio of 0.95 over the sampling window with 0 eviction(s), all age-based and none under memory pressure. The working set stayed resident, the shard-local LRU segments rotated on schedule, and refill traffic to the backing store remained inside the provisioned budget. Prefetch effectiveness held steady and the negative-lookup cache absorbed the usual crawler burst around cycle 5; no keys were invalidated out of band and no coherence warnings were emitted."
     },
     {
       "seq": 6,
@@ -70,7 +70,7 @@
       "lag_ms": 118,
       "success": true,
       "peer": "metrics-collector-replica-0",
-      "detail": "metrics-collector verified segment checksums across every replica and found all of them byte-identical"
+      "detail": "metrics-collector completed its replication round against metrics-collector-replica-0 with 118 ms of measured lag, success=true, and a clean acknowledgement from the follower quorum. The write-ahead segment shipped in one batch, checksum verification matched on both ends, and the follower applied the delta without reordering or gap detection. Watermarks advanced normally under epoch 46; no snapshot fallback was required and the catch-up queue drained back to empty before the next scheduling tick."
     },
     {
       "seq": 7,
@@ -80,7 +80,7 @@
       "task": "segment_compaction",
       "reclaimed_mb": 191,
       "retries": 0,
-      "detail": "object-store compacted its oldest generation of segments and released the reclaimed space back to the pool"
+      "detail": "object-store finished scheduled task 'segment_compaction' and reclaimed 191 MB with 0 retry(ies). The pass ran inside its maintenance window with throttling engaged, held the IO ceiling for the whole run, and released its lease cleanly at the end. Tombstone counts, segment fragmentation, and index bloat all landed inside their post-task targets for cycle 7; the follow-up verification sweep found no orphaned references and scheduled nothing for the remediation queue."
     },
     {
       "seq": 8,
@@ -91,7 +91,7 @@
       "status_code": 200,
       "duration_ms": 146,
       "bytes_out": 1448,
-      "detail": "query-planner completed its scheduled reconciliation pass and reported no drift against the desired state"
+      "detail": "query-planner handled GET /v2/query-planner/status in 146 ms and returned HTTP 200 with 1448 bytes in the response body. The request was served from the warm path with no upstream fan-out; connection reuse was confirmed and the keep-alive pool stayed at its steady-state size. Downstream callers saw p99 latency inside the objective for the interval, and the request completed under trace id req-7204-quer with no retries, no queue spill, and no degradation flags raised by the admission controller."
     },
     {
       "seq": 9,
@@ -100,7 +100,7 @@
       "event": "cache",
       "hit_ratio": 0.9,
       "evictions": 4,
-      "detail": "stream-fanout observed replication lag well inside the configured tolerance for the whole interval"
+      "detail": "stream-fanout reported a cache hit ratio of 0.90 over the sampling window with 4 eviction(s), all age-based and none under memory pressure. The working set stayed resident, the shard-local LRU segments rotated on schedule, and refill traffic to the backing store remained inside the provisioned budget. Prefetch effectiveness held steady and the negative-lookup cache absorbed the usual crawler burst around cycle 9; no keys were invalidated out of band and no coherence warnings were emitted."
     },
     {
       "seq": 10,
@@ -110,7 +110,7 @@
       "lag_ms": 170,
       "success": true,
       "peer": "ingest-gateway-replica-1",
-      "detail": "ingest-gateway re-registered with service discovery after the routine deploy and passed every readiness probe"
+      "detail": "ingest-gateway completed its replication round against ingest-gateway-replica-1 with 170 ms of measured lag, success=true, and a clean acknowledgement from the follower quorum. The write-ahead segment shipped in one batch, checksum verification matched on both ends, and the follower applied the delta without reordering or gap detection. Watermarks advanced normally under epoch 50; no snapshot fallback was required and the catch-up queue drained back to empty before the next scheduling tick."
     },
     {
       "seq": 11,
@@ -120,7 +120,7 @@
       "task": "segment_compaction",
       "reclaimed_mb": 227,
       "retries": 0,
-      "detail": "index-writer rotated its short-lived credentials and re-established upstream sessions without interruption"
+      "detail": "index-writer finished scheduled task 'segment_compaction' and reclaimed 227 MB with 0 retry(ies). The pass ran inside its maintenance window with throttling engaged, held the IO ceiling for the whole run, and released its lease cleanly at the end. Tombstone counts, segment fragmentation, and index bloat all landed inside their post-task targets for cycle 11; the follow-up verification sweep found no orphaned references and scheduled nothing for the remediation queue."
     },
     {
       "seq": 12,
@@ -131,7 +131,7 @@
       "status_code": 200,
       "duration_ms": 114,
       "bytes_out": 1572,
-      "detail": "shard-router observed replication lag well inside the configured tolerance for the whole interval"
+      "detail": "shard-router handled GET /v2/shard-router/status in 114 ms and returned HTTP 200 with 1572 bytes in the response body. The request was served from the warm path with no upstream fan-out; connection reuse was confirmed and the keep-alive pool stayed at its steady-state size. Downstream callers saw p99 latency inside the objective for the interval, and the request completed under trace id req-7256-shar with no retries, no queue spill, and no degradation flags raised by the admission controller."
     },
     {
       "seq": 13,
@@ -140,7 +140,7 @@
       "event": "cache",
       "hit_ratio": 0.94,
       "evictions": 3,
-      "detail": "cache-tier completed its scheduled reconciliation pass and reported no drift against the desired state"
+      "detail": "cache-tier reported a cache hit ratio of 0.94 over the sampling window with 3 eviction(s), all age-based and none under memory pressure. The working set stayed resident, the shard-local LRU segments rotated on schedule, and refill traffic to the backing store remained inside the provisioned budget. Prefetch effectiveness held steady and the negative-lookup cache absorbed the usual crawler burst around cycle 13; no keys were invalidated out of band and no coherence warnings were emitted."
     },
     {
       "seq": 14,
@@ -150,7 +150,7 @@
       "lag_ms": 222,
       "success": true,
       "peer": "replica-sync-replica-2",
-      "detail": "replica-sync verified segment checksums across every replica and found all of them byte-identical"
+      "detail": "replica-sync completed its replication round against replica-sync-replica-2 with 222 ms of measured lag, success=true, and a clean acknowledgement from the follower quorum. The write-ahead segment shipped in one batch, checksum verification matched on both ends, and the follower applied the delta without reordering or gap detection. Watermarks advanced normally under epoch 54; no snapshot fallback was required and the catch-up queue drained back to empty before the next scheduling tick."
     },
     {
       "seq": 15,
@@ -160,7 +160,7 @@
       "task": "segment_compaction",
       "reclaimed_mb": 263,
       "retries": 0,
-      "detail": "auth-broker compacted its oldest generation of segments and released the reclaimed space back to the pool"
+      "detail": "auth-broker finished scheduled task 'segment_compaction' and reclaimed 263 MB with 0 retry(ies). The pass ran inside its maintenance window with throttling engaged, held the IO ceiling for the whole run, and released its lease cleanly at the end. Tombstone counts, segment fragmentation, and index bloat all landed inside their post-task targets for cycle 15; the follow-up verification sweep found no orphaned references and scheduled nothing for the remediation queue."
     },
     {
       "seq": 16,
@@ -171,7 +171,7 @@
       "status_code": 200,
       "duration_ms": 142,
       "bytes_out": 1696,
-      "detail": "metrics-collector completed its scheduled reconciliation pass and reported no drift against the desired state"
+      "detail": "metrics-collector handled GET /v2/metrics-collector/status in 142 ms and returned HTTP 200 with 1696 bytes in the response body. The request was served from the warm path with no upstream fan-out; connection reuse was confirmed and the keep-alive pool stayed at its steady-state size. Downstream callers saw p99 latency inside the objective for the interval, and the request completed under trace id req-7308-metr with no retries, no queue spill, and no degradation flags raised by the admission controller."
     },
     {
       "seq": 17,
@@ -180,7 +180,7 @@
       "event": "cache",
       "hit_ratio": 0.98,
       "evictions": 2,
-      "detail": "object-store observed replication lag well inside the configured tolerance for the whole interval"
+      "detail": "object-store reported a cache hit ratio of 0.98 over the sampling window with 2 eviction(s), all age-based and none under memory pressure. The working set stayed resident, the shard-local LRU segments rotated on schedule, and refill traffic to the backing store remained inside the provisioned budget. Prefetch effectiveness held steady and the negative-lookup cache absorbed the usual crawler burst around cycle 17; no keys were invalidated out of band and no coherence warnings were emitted."
     },
     {
       "seq": 18,
@@ -190,7 +190,7 @@
       "lag_ms": 74,
       "success": true,
       "peer": "query-planner-replica-0",
-      "detail": "query-planner re-registered with service discovery after the routine deploy and passed every readiness probe"
+      "detail": "query-planner completed its replication round against query-planner-replica-0 with 74 ms of measured lag, success=true, and a clean acknowledgement from the follower quorum. The write-ahead segment shipped in one batch, checksum verification matched on both ends, and the follower applied the delta without reordering or gap detection. Watermarks advanced normally under epoch 58; no snapshot fallback was required and the catch-up queue drained back to empty before the next scheduling tick."
     },
     {
       "seq": 19,
@@ -200,7 +200,7 @@
       "task": "segment_compaction",
       "reclaimed_mb": 299,
       "retries": 0,
-      "detail": "stream-fanout rotated its short-lived credentials and re-established upstream sessions without interruption"
+      "detail": "stream-fanout finished scheduled task 'segment_compaction' and reclaimed 299 MB with 0 retry(ies). The pass ran inside its maintenance window with throttling engaged, held the IO ceiling for the whole run, and released its lease cleanly at the end. Tombstone counts, segment fragmentation, and index bloat all landed inside their post-task targets for cycle 19; the follow-up verification sweep found no orphaned references and scheduled nothing for the remediation queue."
     },
     {
       "seq": 20,
@@ -211,7 +211,7 @@
       "status_code": 200,
       "duration_ms": 110,
       "bytes_out": 1820,
-      "detail": "ingest-gateway observed replication lag well inside the configured tolerance for the whole interval"
+      "detail": "ingest-gateway handled GET /v2/ingest-gateway/status in 110 ms and returned HTTP 200 with 1820 bytes in the response body. The request was served from the warm path with no upstream fan-out; connection reuse was confirmed and the keep-alive pool stayed at its steady-state size. Downstream callers saw p99 latency inside the objective for the interval, and the request completed under trace id req-7360-inge with no retries, no queue spill, and no degradation flags raised by the admission controller."
     },
     {
       "seq": 21,
@@ -220,7 +220,7 @@
       "event": "cache",
       "hit_ratio": 0.93,
       "evictions": 1,
-      "detail": "index-writer completed its scheduled reconciliation pass and reported no drift against the desired state"
+      "detail": "index-writer reported a cache hit ratio of 0.93 over the sampling window with 1 eviction(s), all age-based and none under memory pressure. The working set stayed resident, the shard-local LRU segments rotated on schedule, and refill traffic to the backing store remained inside the provisioned budget. Prefetch effectiveness held steady and the negative-lookup cache absorbed the usual crawler burst around cycle 21; no keys were invalidated out of band and no coherence warnings were emitted."
     },
     {
       "seq": 22,
@@ -230,7 +230,7 @@
       "lag_ms": 126,
       "success": true,
       "peer": "shard-router-replica-1",
-      "detail": "shard-router verified segment checksums across every replica and found all of them byte-identical"
+      "detail": "shard-router completed its replication round against shard-router-replica-1 with 126 ms of measured lag, success=true, and a clean acknowledgement from the follower quorum. The write-ahead segment shipped in one batch, checksum verification matched on both ends, and the follower applied the delta without reordering or gap detection. Watermarks advanced normally under epoch 62; no snapshot fallback was required and the catch-up queue drained back to empty before the next scheduling tick."
     },
     {
       "seq": 23,
@@ -241,7 +241,7 @@
       "success": false,
       "retries": 7,
       "duration_ms": 31804,
-      "detail": "object-store connection pool exhausted; the writer could not acquire a lease before the deadline and the batch was abandoned, incident-id INC-4417"
+      "detail": "object-store connection pool exhausted: the writer could not acquire a lease within the 31804 ms deadline and the batch was abandoned after 7 retries, surfacing as HTTP 503 to callers, incident-id INC-4417. Pool telemetry shows every slot pinned by long-running multipart uploads while the lease reaper fell behind, so new writers starved despite healthy upstream capacity. Error budget burn spiked for the interval, the batch remains unwritten pending replay, and the on-call runbook points to raising the reaper cadence and capping multipart concurrency before retrying."
     },
     {
       "seq": 24,
@@ -252,7 +252,7 @@
       "status_code": 200,
       "duration_ms": 138,
       "bytes_out": 1944,
-      "detail": "replica-sync completed its scheduled reconciliation pass and reported no drift against the desired state"
+      "detail": "replica-sync handled GET /v2/replica-sync/status in 138 ms and returned HTTP 200 with 1944 bytes in the response body. The request was served from the warm path with no upstream fan-out; connection reuse was confirmed and the keep-alive pool stayed at its steady-state size. Downstream callers saw p99 latency inside the objective for the interval, and the request completed under trace id req-7412-repl with no retries, no queue spill, and no degradation flags raised by the admission controller."
     },
     {
       "seq": 25,
@@ -261,7 +261,7 @@
       "event": "cache",
       "hit_ratio": 0.97,
       "evictions": 0,
-      "detail": "auth-broker observed replication lag well inside the configured tolerance for the whole interval"
+      "detail": "auth-broker reported a cache hit ratio of 0.97 over the sampling window with 0 eviction(s), all age-based and none under memory pressure. The working set stayed resident, the shard-local LRU segments rotated on schedule, and refill traffic to the backing store remained inside the provisioned budget. Prefetch effectiveness held steady and the negative-lookup cache absorbed the usual crawler burst around cycle 25; no keys were invalidated out of band and no coherence warnings were emitted."
     },
     {
       "seq": 26,
@@ -271,7 +271,7 @@
       "lag_ms": 178,
       "success": true,
       "peer": "metrics-collector-replica-2",
-      "detail": "metrics-collector re-registered with service discovery after the routine deploy and passed every readiness probe"
+      "detail": "metrics-collector completed its replication round against metrics-collector-replica-2 with 178 ms of measured lag, success=true, and a clean acknowledgement from the follower quorum. The write-ahead segment shipped in one batch, checksum verification matched on both ends, and the follower applied the delta without reordering or gap detection. Watermarks advanced normally under epoch 66; no snapshot fallback was required and the catch-up queue drained back to empty before the next scheduling tick."
     },
     {
       "seq": 27,
@@ -281,7 +281,7 @@
       "task": "segment_compaction",
       "reclaimed_mb": 371,
       "retries": 0,
-      "detail": "object-store rotated its short-lived credentials and re-established upstream sessions without interruption"
+      "detail": "object-store finished scheduled task 'segment_compaction' and reclaimed 371 MB with 0 retry(ies). The pass ran inside its maintenance window with throttling engaged, held the IO ceiling for the whole run, and released its lease cleanly at the end. Tombstone counts, segment fragmentation, and index bloat all landed inside their post-task targets for cycle 27; the follow-up verification sweep found no orphaned references and scheduled nothing for the remediation queue."
     },
     {
       "seq": 28,
@@ -292,7 +292,7 @@
       "status_code": 200,
       "duration_ms": 106,
       "bytes_out": 2068,
-      "detail": "query-planner observed replication lag well inside the configured tolerance for the whole interval"
+      "detail": "query-planner handled GET /v2/query-planner/status in 106 ms and returned HTTP 200 with 2068 bytes in the response body. The request was served from the warm path with no upstream fan-out; connection reuse was confirmed and the keep-alive pool stayed at its steady-state size. Downstream callers saw p99 latency inside the objective for the interval, and the request completed under trace id req-7464-quer with no retries, no queue spill, and no degradation flags raised by the admission controller."
     },
     {
       "seq": 29,
@@ -301,7 +301,7 @@
       "event": "cache",
       "hit_ratio": 0.92,
       "evictions": 4,
-      "detail": "stream-fanout completed its scheduled reconciliation pass and reported no drift against the desired state"
+      "detail": "stream-fanout reported a cache hit ratio of 0.92 over the sampling window with 4 eviction(s), all age-based and none under memory pressure. The working set stayed resident, the shard-local LRU segments rotated on schedule, and refill traffic to the backing store remained inside the provisioned budget. Prefetch effectiveness held steady and the negative-lookup cache absorbed the usual crawler burst around cycle 29; no keys were invalidated out of band and no coherence warnings were emitted."
     },
     {
       "seq": 30,
@@ -311,7 +311,7 @@
       "lag_ms": 230,
       "success": true,
       "peer": "ingest-gateway-replica-0",
-      "detail": "ingest-gateway verified segment checksums across every replica and found all of them byte-identical"
+      "detail": "ingest-gateway completed its replication round against ingest-gateway-replica-0 with 230 ms of measured lag, success=true, and a clean acknowledgement from the follower quorum. The write-ahead segment shipped in one batch, checksum verification matched on both ends, and the follower applied the delta without reordering or gap detection. Watermarks advanced normally under epoch 70; no snapshot fallback was required and the catch-up queue drained back to empty before the next scheduling tick."
     },
     {
       "seq": 31,
@@ -321,7 +321,7 @@
       "task": "segment_compaction",
       "reclaimed_mb": 407,
       "retries": 0,
-      "detail": "index-writer compacted its oldest generation of segments and released the reclaimed space back to the pool"
+      "detail": "index-writer finished scheduled task 'segment_compaction' and reclaimed 407 MB with 0 retry(ies). The pass ran inside its maintenance window with throttling engaged, held the IO ceiling for the whole run, and released its lease cleanly at the end. Tombstone counts, segment fragmentation, and index bloat all landed inside their post-task targets for cycle 31; the follow-up verification sweep found no orphaned references and scheduled nothing for the remediation queue."
     },
     {
       "seq": 32,
@@ -332,7 +332,7 @@
       "status_code": 200,
       "duration_ms": 134,
       "bytes_out": 2192,
-      "detail": "shard-router completed its scheduled reconciliation pass and reported no drift against the desired state"
+      "detail": "shard-router handled GET /v2/shard-router/status in 134 ms and returned HTTP 200 with 2192 bytes in the response body. The request was served from the warm path with no upstream fan-out; connection reuse was confirmed and the keep-alive pool stayed at its steady-state size. Downstream callers saw p99 latency inside the objective for the interval, and the request completed under trace id req-7516-shar with no retries, no queue spill, and no degradation flags raised by the admission controller."
     },
     {
       "seq": 33,
@@ -341,7 +341,7 @@
       "event": "cache",
       "hit_ratio": 0.96,
       "evictions": 3,
-      "detail": "cache-tier observed replication lag well inside the configured tolerance for the whole interval"
+      "detail": "cache-tier reported a cache hit ratio of 0.96 over the sampling window with 3 eviction(s), all age-based and none under memory pressure. The working set stayed resident, the shard-local LRU segments rotated on schedule, and refill traffic to the backing store remained inside the provisioned budget. Prefetch effectiveness held steady and the negative-lookup cache absorbed the usual crawler burst around cycle 33; no keys were invalidated out of band and no coherence warnings were emitted."
     },
     {
       "seq": 34,
@@ -351,7 +351,7 @@
       "lag_ms": 82,
       "success": true,
       "peer": "replica-sync-replica-1",
-      "detail": "replica-sync re-registered with service discovery after the routine deploy and passed every readiness probe"
+      "detail": "replica-sync completed its replication round against replica-sync-replica-1 with 82 ms of measured lag, success=true, and a clean acknowledgement from the follower quorum. The write-ahead segment shipped in one batch, checksum verification matched on both ends, and the follower applied the delta without reordering or gap detection. Watermarks advanced normally under epoch 74; no snapshot fallback was required and the catch-up queue drained back to empty before the next scheduling tick."
     },
     {
       "seq": 35,
@@ -361,7 +361,7 @@
       "task": "segment_compaction",
       "reclaimed_mb": 443,
       "retries": 0,
-      "detail": "auth-broker rotated its short-lived credentials and re-established upstream sessions without interruption"
+      "detail": "auth-broker finished scheduled task 'segment_compaction' and reclaimed 443 MB with 0 retry(ies). The pass ran inside its maintenance window with throttling engaged, held the IO ceiling for the whole run, and released its lease cleanly at the end. Tombstone counts, segment fragmentation, and index bloat all landed inside their post-task targets for cycle 35; the follow-up verification sweep found no orphaned references and scheduled nothing for the remediation queue."
     },
     {
       "seq": 36,
@@ -372,7 +372,7 @@
       "status_code": 200,
       "duration_ms": 102,
       "bytes_out": 2316,
-      "detail": "metrics-collector observed replication lag well inside the configured tolerance for the whole interval"
+      "detail": "metrics-collector handled GET /v2/metrics-collector/status in 102 ms and returned HTTP 200 with 2316 bytes in the response body. The request was served from the warm path with no upstream fan-out; connection reuse was confirmed and the keep-alive pool stayed at its steady-state size. Downstream callers saw p99 latency inside the objective for the interval, and the request completed under trace id req-7568-metr with no retries, no queue spill, and no degradation flags raised by the admission controller."
     },
     {
       "seq": 37,
@@ -381,7 +381,7 @@
       "event": "cache",
       "hit_ratio": 0.91,
       "evictions": 2,
-      "detail": "object-store completed its scheduled reconciliation pass and reported no drift against the desired state"
+      "detail": "object-store reported a cache hit ratio of 0.91 over the sampling window with 2 eviction(s), all age-based and none under memory pressure. The working set stayed resident, the shard-local LRU segments rotated on schedule, and refill traffic to the backing store remained inside the provisioned budget. Prefetch effectiveness held steady and the negative-lookup cache absorbed the usual crawler burst around cycle 37; no keys were invalidated out of band and no coherence warnings were emitted."
     },
     {
       "seq": 38,
@@ -391,7 +391,7 @@
       "lag_ms": 134,
       "success": true,
       "peer": "query-planner-replica-2",
-      "detail": "query-planner verified segment checksums across every replica and found all of them byte-identical"
+      "detail": "query-planner completed its replication round against query-planner-replica-2 with 134 ms of measured lag, success=true, and a clean acknowledgement from the follower quorum. The write-ahead segment shipped in one batch, checksum verification matched on both ends, and the follower applied the delta without reordering or gap detection. Watermarks advanced normally under epoch 78; no snapshot fallback was required and the catch-up queue drained back to empty before the next scheduling tick."
     },
     {
       "seq": 39,
@@ -401,7 +401,7 @@
       "task": "segment_compaction",
       "reclaimed_mb": 479,
       "retries": 0,
-      "detail": "stream-fanout compacted its oldest generation of segments and released the reclaimed space back to the pool"
+      "detail": "stream-fanout finished scheduled task 'segment_compaction' and reclaimed 479 MB with 0 retry(ies). The pass ran inside its maintenance window with throttling engaged, held the IO ceiling for the whole run, and released its lease cleanly at the end. Tombstone counts, segment fragmentation, and index bloat all landed inside their post-task targets for cycle 39; the follow-up verification sweep found no orphaned references and scheduled nothing for the remediation queue."
     }
   ]
 }

--- a/examples/quickstart.ipynb
+++ b/examples/quickstart.ipynb
@@ -5,354 +5,1230 @@
    "id": "intro",
    "metadata": {},
    "source": [
-    "# tokenfold quickstart (Python)\n",
+    "# Tokenfold quickstart\n",
     "\n",
-    "The notebook version of [`quickstart.py`](quickstart.py) — the same core operations, one\n",
-    "per cell, so you can poke at the receipts between steps, plus two extras only the\n",
-    "notebook covers: the Anthropic-format helper and a dry-run preview with `inspect`.\n",
+    "Tokenfold compresses LLM requests and JSON and returns a receipt showing exactly what\n",
+    "changed. **Lossless compression is the default**; recoverable lossy pruning happens only\n",
+    "when you explicitly ask for it, and every call — lossless or lossy — hands back a receipt.\n",
     "\n",
+    "This tour runs entirely offline against the fixtures next to this notebook: no network\n",
+    "call, no API key, no provider request — Tokenfold demo data is written only to a\n",
+    "temporary directory. It takes about five minutes to read and runs in seconds once the\n",
+    "kernel is up.\n",
+    "\n",
+    "## Setup\n",
+    "\n",
+    "```bash\n",
+    "pip install \"tokenfold>=0.4.1\"   # 0.4.1 is the first release with Python lossy pruning and retrieval\n",
+    "pip install jupyter              # or open this notebook in a Jupyter environment you already have\n",
     "```\n",
-    "pip install tokenfold\n",
-    "```\n",
     "\n",
-    "From a clone, build the binding instead:\n",
+    "From a clone, build the binding instead. The `-m` path is required — bare `maturin develop`\n",
+    "fails because there is no repository-root `pyproject.toml`:\n",
     "\n",
-    "```\n",
+    "```bash\n",
     "maturin develop -m crates/tokenfold-py/Cargo.toml\n",
     "```\n",
     "\n",
-    "Everything here is **lossless**: these calls only ever restructure data, never discard\n",
-    "it. Lossy array pruning is opt-in and stays off unless you ask for it\n",
-    "(`compress(..., lossy=LossyPath.HEURISTIC)`, recoverable via `retrieve()`) — see\n",
-    "[`lossy_pruning.py`](lossy_pruning.py) for that end to end."
+    "## What this notebook covers\n",
+    "\n",
+    "The six public functions of the Python package, plus the types that configure them:\n",
+    "\n",
+    "| Workflow | Public API |\n",
+    "| --- | --- |\n",
+    "| Generic JSON and the other accepted input formats | `compress` |\n",
+    "| Side-effect-free preview | `inspect` |\n",
+    "| OpenAI-style message lists | `compress_messages` |\n",
+    "| Complete provider request bodies | `compress_openai_payload`, `compress_anthropic_payload` |\n",
+    "| Recoverable lossy pruning and recovery | `LossyPath` + `retrieve` |\n",
+    "| Reusable settings and typed receipts | `CompressionPolicy`, `CompressionMode`, `InputFormat`, `Status` |\n",
+    "\n",
+    "Section 9 covers Tokenfold Select, the optional fine-tuned ranker. It is a separate\n",
+    "runtime, so it stays disabled by default and downloads nothing unless you turn it on.\n",
+    "\n",
+    "## 1. Imports and helpers\n",
+    "\n",
+    "Nothing but the standard library and `tokenfold`. Two small helpers keep every result in\n",
+    "the same shape, so plain Python renders the whole notebook without `pandas` or a plotting\n",
+    "library."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "setup",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-21T00:06:53.355564Z",
+     "iopub.status.busy": "2026-08-21T00:06:53.355564Z",
+     "iopub.status.idle": "2026-08-21T00:06:53.697647Z",
+     "shell.execute_reply": "2026-08-21T00:06:53.697144Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "tokenfold 0.4.1\n"
+     ]
+    }
+   ],
    "source": [
     "import json\n",
+    "import tempfile\n",
+    "from importlib.metadata import version\n",
     "from pathlib import Path\n",
     "\n",
     "import tokenfold\n",
     "\n",
-    "# The same payload the Rust and Node examples use.\n",
-    "PAYLOAD = json.loads(Path(\"openai_payload.json\").read_text())\n",
-    "[m[\"role\"] for m in PAYLOAD[\"messages\"]]"
+    "# The extension does not export `tokenfold.__version__`; ask the installed distribution,\n",
+    "# so a stale environment is visible immediately.\n",
+    "print(\"tokenfold\", version(\"tokenfold\"))\n",
+    "\n",
+    "# Works whether the notebook is launched from the repository root or from examples/.\n",
+    "EXAMPLES = Path(\"examples\") if Path(\"examples\").is_dir() else Path(\".\")\n",
+    "\n",
+    "\n",
+    "def show(label, result):\n",
+    "    \"\"\"One consistent line per result: label, before, after, saved, status, transforms.\"\"\"\n",
+    "    report = result.report\n",
+    "    applied = [t[\"id\"] for t in report.raw[\"transforms\"] if t[\"status\"] == \"applied\"]\n",
+    "    print(\n",
+    "        f\"{label:<22} {report.original_tokens:>5,} -> {report.compressed_tokens:>5,} tokens\"\n",
+    "        f\"  ({report.savings_pct:5.1f}% saved)\"\n",
+    "        f\"  {str(report.status).replace('Status.', ''):<18}\"\n",
+    "        f\"  {', '.join(applied) or '(none applied)'}\"\n",
+    "    )\n",
+    "\n",
+    "\n",
+    "def transform_rows(result):\n",
+    "    \"\"\"Per-transform detail from the raw receipt, small enough to display inline.\"\"\"\n",
+    "    return [\n",
+    "        {\n",
+    "            \"transform\": t[\"id\"],\n",
+    "            \"status\": t[\"status\"],\n",
+    "            \"saved_tokens\": t[\"saved_tokens\"],\n",
+    "            \"skipped_reason\": t[\"skipped_reason\"],\n",
+    "        }\n",
+    "        for t in result.report.raw[\"transforms\"]\n",
+    "    ]"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "m1",
+   "id": "lossless-json",
    "metadata": {},
    "source": [
-    "## 1. Compress a message list\n",
+    "## 2. First win: lossless generic JSON\n",
     "\n",
-    "The common case: you have a `messages` list bound for the Chat Completions API.\n",
-    "`compress_messages` hands back a compressed list plus exact token accounting.\n",
+    "The smallest useful call. Repeated record keys fold into a compact column layout and\n",
+    "repeated values are stored once, so the payload stays valid JSON and every transform is\n",
+    "round-trip checked before it is kept.\n",
     "\n",
-    "The example below is deliberately messy: a debugging session where someone pasted\n",
-    "live-looking secrets into the chat. `compress_messages` redacts them before the\n",
-    "request ever goes out, and the token savings below are the real, measured effect of\n",
-    "that — not a hypothetical."
+    "One honest caveat: the folded form is valid, self-describing JSON, but it is no longer\n",
+    "the *original application schema* — it is meant for LLM context and Tokenfold-aware\n",
+    "consumers, not as a drop-in response for an existing API client. When the wire shape must\n",
+    "survive untouched, use the provider helpers in section 6, whose output stays a valid\n",
+    "provider request body.\n",
+    "\n",
+    "Pass `format=` explicitly. Unlike the CLI, the Python binding does not sniff the input\n",
+    "format — section 7 shows exactly what each format does here.\n",
+    "\n",
+    "This tour uses the typed enums throughout (`InputFormat.JSON`, `CompressionMode.BALANCED`,\n",
+    "`LossyPath.HEURISTIC`), because they are discoverable from an editor and fail loudly on a\n",
+    "typo. The equivalent strings — `format=\"JSON\"`, `mode=\"BALANCED\"` — are accepted everywhere\n",
+    "too."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "c1",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 2,
+   "id": "compress-json",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-21T00:06:53.701653Z",
+     "iopub.status.busy": "2026-08-21T00:06:53.701653Z",
+     "iopub.status.idle": "2026-08-21T00:06:54.220012Z",
+     "shell.execute_reply": "2026-08-21T00:06:54.219007Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "a 30-record user API response, 12,760 bytes\n",
+      "generic JSON           3,812 -> 1,376 tokens  ( 63.9% saved)  BEST_EFFORT         json_minify, json_field_fold, json_value_dict\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "{'value dictionary': [{'tier': 'pro',\n",
+       "   'seats': 5,\n",
+       "   'region': 'us-east-1',\n",
+       "   'billing_cycle': 'annual',\n",
+       "   'support_level': 'priority'},\n",
+       "  ['read', 'write', 'billing', 'admin'],\n",
+       "  {'tier': 'free',\n",
+       "   'seats': 1,\n",
+       "   'region': 'us-east-1',\n",
+       "   'billing_cycle': 'monthly',\n",
+       "   'support_level': 'community'},\n",
+       "  {'tier': 'team',\n",
+       "   'seats': 25,\n",
+       "   'region': 'eu-west-1',\n",
+       "   'billing_cycle': 'annual',\n",
+       "   'support_level': 'priority'}],\n",
+       " 'columns': ['id',\n",
+       "  'name',\n",
+       "  'role',\n",
+       "  'active',\n",
+       "  'email_verified',\n",
+       "  'last_login',\n",
+       "  'plan',\n",
+       "  'permissions'],\n",
+       " 'rows 0-2 of 30': [[1001,\n",
+       "   'Ada Lovelace',\n",
+       "   'admin',\n",
+       "   True,\n",
+       "   True,\n",
+       "   '2026-08-01T09:00:00Z',\n",
+       "   {'__tf_ref__': 0},\n",
+       "   {'__tf_ref__': 1}],\n",
+       "  [1002,\n",
+       "   'Alan Turing',\n",
+       "   'member',\n",
+       "   True,\n",
+       "   True,\n",
+       "   '2026-08-02T09:01:00Z',\n",
+       "   {'__tf_ref__': 2},\n",
+       "   ['read', 'write']],\n",
+       "  [1003,\n",
+       "   'Grace Hopper',\n",
+       "   'member',\n",
+       "   True,\n",
+       "   True,\n",
+       "   '2026-08-03T09:02:00Z',\n",
+       "   {'__tf_ref__': 3},\n",
+       "   ['read', 'write']]]}"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "# A realistic slip: someone pastes their whole .env into a debugging chat.\n",
-    "# tokenfold catches and redacts every secret before this reaches the API --\n",
-    "# redaction is best-effort (see the warning below), never a substitute for not\n",
-    "# leaking secrets in the first place.\n",
-    "JWT = (\n",
-    "    \"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.\"\n",
-    "    \"eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U\"\n",
+    "source = (EXAMPLES / \"api_response.json\").read_text(encoding=\"utf-8\")\n",
+    "records = json.loads(source)[\"results\"]\n",
+    "print(f\"a {len(records)}-record user API response, {len(source):,} bytes\")\n",
+    "\n",
+    "result = tokenfold.compress(source, format=tokenfold.InputFormat.JSON)\n",
+    "show(\"generic JSON\", result)\n",
+    "\n",
+    "# Still valid JSON: repeated keys became one column list, and each repeated\n",
+    "# plan/permissions object is stored once in a value dictionary that rows point into.\n",
+    "# Shown here: the dictionary and the first three rows.\n",
+    "compact = json.loads(result.payload)\n",
+    "folded = compact[\"__tf_data__\"][\"results\"]\n",
+    "{\n",
+    "    \"value dictionary\": compact[\"__tf_dict__\"],\n",
+    "    \"columns\": folded[\"__tf_cols__\"],\n",
+    "    f\"rows 0-2 of {len(folded['__tf_rows__'])}\": folded[\"__tf_rows__\"][:3],\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "preview-receipt",
+   "metadata": {},
+   "source": [
+    "## 3. Preview first, then read the receipt\n",
+    "\n",
+    "`inspect` computes the same result without changing your input, which is how you decide\n",
+    "whether compressing is worth it. Note the split: the **payload** comes back untouched\n",
+    "while the **report** describes the compressed size it projects.\n",
+    "\n",
+    "Every result promotes the common fields to typed attributes (`report.original_tokens`,\n",
+    "`report.status`, `report.estimator`, `report.warnings`, ...) and keeps the complete\n",
+    "receipt as a plain dictionary at `report.raw`. Two `raw` keys stay quiet on an\n",
+    "unconstrained lossless run and light up later: `budget` reports `target_tokens: None`\n",
+    "until section 4 sets one, and `retrieval` is `None` until section 8 opts into pruning."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "inspect",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-21T00:06:54.223012Z",
+     "iopub.status.busy": "2026-08-21T00:06:54.223012Z",
+     "iopub.status.idle": "2026-08-21T00:06:54.707569Z",
+     "shell.execute_reply": "2026-08-21T00:06:54.706564Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "dry-run preview        3,812 -> 1,376 tokens  ( 63.9% saved)  BEST_EFFORT         json_minify, json_field_fold, json_value_dict\n",
+      "  schema_version=1.0  mode=balanced  format=json  task_scope=all  saved_tokens=2436\n",
+      "  estimator=tiktoken/o200k_base (exact=True)  warnings=['redaction is best-effort; it is not a guarantee that no secret survives']\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "{'estimator': {'backend': 'tiktoken', 'model': 'o200k_base', 'is_exact': True},\n",
+       " 'warnings': [{'code': 'unredacted_content_possible',\n",
+       "   'severity': 'info',\n",
+       "   'transform': 'secret_redaction',\n",
+       "   'message': 'redaction is best-effort; it is not a guarantee that no secret survives'}],\n",
+       " 'budget': {'target_tokens': None,\n",
+       "  'protected_floor': 0,\n",
+       "  'achieved_tokens': 1376},\n",
+       " 'retrieval': None,\n",
+       " 'transforms': [{'transform': 'secret_redaction',\n",
+       "   'status': 'no_op',\n",
+       "   'saved_tokens': 0,\n",
+       "   'skipped_reason': None},\n",
+       "  {'transform': 'json_minify',\n",
+       "   'status': 'applied',\n",
+       "   'saved_tokens': 1446,\n",
+       "   'skipped_reason': None},\n",
+       "  {'transform': 'json_field_fold',\n",
+       "   'status': 'applied',\n",
+       "   'saved_tokens': 511,\n",
+       "   'skipped_reason': None},\n",
+       "  {'transform': 'json_value_dict',\n",
+       "   'status': 'applied',\n",
+       "   'saved_tokens': 479,\n",
+       "   'skipped_reason': None}]}"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "preview = tokenfold.inspect(source, format=tokenfold.InputFormat.JSON)\n",
+    "show(\"dry-run preview\", preview)\n",
+    "\n",
+    "# A preview never changes your input — only the receipt changes.\n",
+    "assert preview.payload == source.encode(\"utf-8\")\n",
+    "\n",
+    "# Promoted typed fields: the everyday subset, straight off the report object.\n",
+    "print(\n",
+    "    f\"  schema_version={preview.report.schema_version}\"\n",
+    "    f\"  mode={preview.report.mode}  format={preview.report.format}\"\n",
+    "    f\"  task_scope={preview.report.task_scope}\"\n",
+    "    f\"  saved_tokens={preview.report.saved_tokens}\"\n",
     ")\n",
+    "print(\n",
+    "    f\"  estimator={preview.report.estimator.backend}/{preview.report.estimator.model}\"\n",
+    "    f\" (exact={preview.report.estimator.is_exact})  warnings={preview.report.warnings}\"\n",
+    ")\n",
+    "\n",
+    "# ...and the same receipt in full, as a plain dictionary.\n",
+    "raw = preview.report.raw\n",
+    "{\n",
+    "    \"estimator\": raw[\"estimator\"],\n",
+    "    \"warnings\": raw[\"warnings\"],\n",
+    "    \"budget\": raw[\"budget\"],        # target_tokens is None: nothing was constrained\n",
+    "    \"retrieval\": raw[\"retrieval\"],  # None until section 8 opts into lossy pruning\n",
+    "    \"transforms\": transform_rows(preview),\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "controls",
+   "metadata": {},
+   "source": [
+    "## 4. Budgets, modes, and reusable policy\n",
+    "\n",
+    "Three knobs control the trade-off: the mode, an optional token target, and per-transform\n",
+    "controls.\n",
+    "\n",
+    "- **Mode** — `CONSERVATIVE` keeps only the safest structural transforms, `BALANCED` is the\n",
+    "  default, and `AGGRESSIVE` allows the most. A mode does two things: it gates *which*\n",
+    "  transforms may run (folding stays out of conservative), and it caps *how big a bite* a\n",
+    "  content-trimming transform may take — a transform whose saving would exceed the mode's\n",
+    "  ratio cap is skipped entirely, and the receipt says `not_enabled_in_mode`. On generic\n",
+    "  JSON every transform is lossless and uncapped, so balanced and aggressive land in the\n",
+    "  same place there; the second comparison below uses a provider payload whose verbose tool\n",
+    "  schema only an aggressive-sized cap allows trimming.\n",
+    "- **`CompressionPolicy`** — bundle settings once and reuse them across calls. Derive a\n",
+    "  target from a measured result rather than hardcoding a literal that silently drifts out\n",
+    "  of reach as transforms improve.\n",
+    "- **Status** — `COMPRESSED` means a target you set was provably met. `BEST_EFFORT` means\n",
+    "  \"compressed as far as this input goes\", which is also what an unconstrained run reports —\n",
+    "  so read `is_over_budget()` next to a target you actually set. `UNREACHABLE_TARGET`\n",
+    "  appears in section 6.\n",
+    "- **Transform controls** — `disable=[...]` is a per-call keyword on `compress` and both\n",
+    "  provider helpers (`inspect` does not take it). `enable=[...]` and `experimental=True`\n",
+    "  exist only on `CompressionPolicy`, and this quickstart leaves experimental transforms\n",
+    "  off.\n",
+    "\n",
+    "One more gate worth naming: a budget-constrained call fails closed with `EstimatorError`\n",
+    "(a `TokenFoldError`) when only a heuristic token estimator is available, unless you pass\n",
+    "`allow_heuristic_budget=True`. This build has the exact `o200k_base` estimator, so the gate\n",
+    "never trips here."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "modes",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-21T00:06:54.710569Z",
+     "iopub.status.busy": "2026-08-21T00:06:54.710569Z",
+     "iopub.status.idle": "2026-08-21T00:06:57.374190Z",
+     "shell.execute_reply": "2026-08-21T00:06:57.373186Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "generic JSON (lossless transforms, no ratio caps):\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CONSERVATIVE           3,812 -> 2,366 tokens  ( 37.9% saved)  BEST_EFFORT         json_minify\n",
+      "BALANCED               3,812 -> 1,376 tokens  ( 63.9% saved)  BEST_EFFORT         json_minify, json_field_fold, json_value_dict\n",
+      "AGGRESSIVE             3,812 -> 1,376 tokens  ( 63.9% saved)  BEST_EFFORT         json_minify, json_field_fold, json_value_dict\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "an OpenAI request with a verbose tool schema (mode ratio caps decide):\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CONSERVATIVE             517 ->   354 tokens  ( 31.5% saved)  BEST_EFFORT         json_minify\n",
+      "BALANCED                 517 ->   354 tokens  ( 31.5% saved)  BEST_EFFORT         json_minify\n",
+      "AGGRESSIVE               517 ->   215 tokens  ( 58.4% saved)  BEST_EFFORT         json_minify, schema_compaction\n"
+     ]
+    }
+   ],
+   "source": [
+    "MODES = (\n",
+    "    tokenfold.CompressionMode.CONSERVATIVE,\n",
+    "    tokenfold.CompressionMode.BALANCED,\n",
+    "    tokenfold.CompressionMode.AGGRESSIVE,\n",
+    ")\n",
+    "\n",
+    "# Generic JSON: conservative stays at minify-only; folding separates it from the rest.\n",
+    "print(\"generic JSON (lossless transforms, no ratio caps):\")\n",
+    "for mode in MODES:\n",
+    "    show(\n",
+    "        str(mode).replace(\"CompressionMode.\", \"\"),\n",
+    "        tokenfold.compress(source, format=tokenfold.InputFormat.JSON, mode=mode),\n",
+    "    )\n",
+    "\n",
+    "# A provider payload whose tool schema drags a large illustrative examples array along.\n",
+    "# Trimming it would save ~40% of the payload — a bigger bite than conservative (15%) or\n",
+    "# balanced (30%) permit, so only aggressive's 50% cap lets schema_compaction run.\n",
+    "verbose_request = json.loads((EXAMPLES / \"openai_payload.json\").read_text(encoding=\"utf-8\"))\n",
+    "location = verbose_request[\"tools\"][0][\"function\"][\"parameters\"][\"properties\"][\"location\"]\n",
+    "location[\"examples\"] = [f\"Sample City {n}, CA\" for n in range(20)]\n",
+    "verbose_body = json.dumps(verbose_request, indent=2)\n",
+    "\n",
+    "print(\"\\nan OpenAI request with a verbose tool schema (mode ratio caps decide):\")\n",
+    "conservative, balanced, aggressive = (\n",
+    "    tokenfold.compress(verbose_body, format=tokenfold.InputFormat.OPENAI_JSON, mode=mode)\n",
+    "    for mode in MODES\n",
+    ")\n",
+    "show(\"CONSERVATIVE\", conservative)\n",
+    "show(\"BALANCED\", balanced)\n",
+    "show(\"AGGRESSIVE\", aggressive)\n",
+    "\n",
+    "# The receipt names the reason, and only aggressive's result is smaller.\n",
+    "balanced_schema = next(\n",
+    "    t for t in balanced.report.raw[\"transforms\"] if t[\"id\"] == \"schema_compaction\"\n",
+    ")\n",
+    "assert balanced_schema[\"skipped_reason\"] == \"not_enabled_in_mode\"\n",
+    "assert aggressive.report.compressed_tokens < balanced.report.compressed_tokens"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "policy-and-budget",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-21T00:06:57.377349Z",
+     "iopub.status.busy": "2026-08-21T00:06:57.377349Z",
+     "iopub.status.idle": "2026-08-21T00:06:58.831453Z",
+     "shell.execute_reply": "2026-08-21T00:06:58.830449Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "target met             3,812 -> 1,376 tokens  ( 63.9% saved)  COMPRESSED          json_minify, json_field_fold, json_value_dict\n",
+      "  saved_pct=63.9  is_over_budget=False  budget={'target_tokens': 1396, 'protected_floor': 0, 'achieved_tokens': 1376}\n",
+      "tight target           3,812 -> 1,376 tokens  ( 63.9% saved)  BEST_EFFORT         json_minify, json_field_fold, json_value_dict\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "without json_value_dict 3,812 -> 1,855 tokens  ( 51.3% saved)  BEST_EFFORT         json_minify, json_field_fold\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Derive the target from the measured lossless result, never from a hardcoded literal.\n",
+    "budget_policy = tokenfold.CompressionPolicy(\n",
+    "    mode=tokenfold.CompressionMode.BALANCED,\n",
+    "    target_tokens=result.report.compressed_tokens + 20,\n",
+    ")\n",
+    "budgeted = tokenfold.compress(source, policy=budget_policy, format=tokenfold.InputFormat.JSON)\n",
+    "show(\"target met\", budgeted)\n",
+    "print(\n",
+    "    f\"  saved_pct={budgeted.saved_pct():.1f}\"\n",
+    "    f\"  is_over_budget={budgeted.is_over_budget()}\"\n",
+    "    f\"  budget={budgeted.report.raw['budget']}\"\n",
+    ")\n",
+    "assert budgeted.report.status == tokenfold.Status.COMPRESSED\n",
+    "\n",
+    "# A deliberately tight target, previewed rather than compressed. BEST_EFFORT is an honest\n",
+    "# \"this is as far as the input goes\", not a failure — and nothing was destroyed reaching it.\n",
+    "tight = tokenfold.inspect(\n",
+    "    source,\n",
+    "    format=tokenfold.InputFormat.JSON,\n",
+    "    target_tokens=result.report.compressed_tokens // 4,\n",
+    ")\n",
+    "show(\"tight target\", tight)\n",
+    "assert tight.report.status == tokenfold.Status.BEST_EFFORT\n",
+    "assert tight.is_over_budget()  # True here — a target was set and provably missed\n",
+    "\n",
+    "# `disable` takes transform ids straight from the receipt above.\n",
+    "last_applied = [t[\"transform\"] for t in transform_rows(result) if t[\"status\"] == \"applied\"][-1]\n",
+    "without = tokenfold.compress(\n",
+    "    source, format=tokenfold.InputFormat.JSON, disable=[last_applied]\n",
+    ")\n",
+    "show(f\"without {last_applied}\", without)\n",
+    "assert last_applied not in [\n",
+    "    t[\"transform\"] for t in transform_rows(without) if t[\"status\"] == \"applied\"\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "messages",
+   "metadata": {},
+   "source": [
+    "## 5. Message lists and safety behavior\n",
+    "\n",
+    "`compress_messages` is the wrapper to reach for when you already hold an OpenAI-style\n",
+    "message list. Its surface is deliberately narrower than `compress`: it takes\n",
+    "`token_budget=` and `mode=` only — no policy, format, `disable`, or `target_tokens` — its\n",
+    "`model` argument does not change tokenization today, and it returns a\n",
+    "`MessagesCompressionResult` carrying token fields and `transforms_applied` but no\n",
+    "`saved_pct()` / `is_over_budget()`.\n",
+    "\n",
+    "Detected secrets are redacted before anything is reported or stored. **Redaction is\n",
+    "best-effort defense in depth, not permission to put real secrets in prompts.** The values\n",
+    "below are fake."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "compress-messages",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-21T00:06:58.834452Z",
+     "iopub.status.busy": "2026-08-21T00:06:58.834452Z",
+     "iopub.status.idle": "2026-08-21T00:06:59.236628Z",
+     "shell.execute_reply": "2026-08-21T00:06:59.235542Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "message list              62 ->    61 tokens  (  1.6% saved)  BEST_EFFORT         secret_redaction\n",
+      "  tokens_before=62 tokens_after=61 tokens_saved=1 transforms_applied=['secret_redaction']\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "{'role': 'user',\n",
+       " 'content': 'Debug this config (the values are fake):\\nOPENAI_API_KEY=[REDACTED:api_key]\\nAWS_ACCESS_KEY_ID=[REDACTED:aws_key]'}"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
     "messages = [\n",
-    "    {\"role\": \"system\", \"content\": \"You are a careful senior software engineer.\"},\n",
+    "    {\"role\": \"system\", \"content\": \"You are concise.\"},\n",
     "    {\n",
     "        \"role\": \"user\",\n",
     "        \"content\": (\n",
-    "            \"Deploy is failing. Here is the full .env I'm using, can you spot the \"\n",
-    "            \"problem?\\n\\n\"\n",
-    "            'OPENAI_API_KEY=sk-ThisIsNotARealKey1234567890ABCDEF\\n'\n",
-    "            'STRIPE_SECRET_KEY=sk-AnotherFakeSecretKeyForStripe0987654321XY\\n'\n",
-    "            'AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE\\n'\n",
-    "            'DATABASE_URL=https://admin:hunter2@prod-db.internal:5432/app\\n'\n",
-    "            'REPLICA_URL=https://readonly:swordfish@prod-db-replica.internal:5432/app\\n'\n",
-    "            f'AUTH_HEADER=Bearer {JWT}\\n'\n",
-    "            f'SESSION_TOKEN=Bearer {JWT}\\n'\n",
+    "            \"Debug this config (the values are fake):\\n\"\n",
+    "            \"OPENAI_API_KEY=sk-example1234567890abcdefghijklmnop\\n\"\n",
+    "            \"AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE\"\n",
     "        ),\n",
     "    },\n",
     "]\n",
     "\n",
-    "result = tokenfold.compress_messages(messages, model=\"gpt-4o\", mode=\"BALANCED\")\n",
+    "chat = tokenfold.compress_messages(\n",
+    "    messages,\n",
+    "    model=\"gpt-4o\",\n",
+    "    mode=tokenfold.CompressionMode.BALANCED,\n",
+    ")\n",
+    "show(\"message list\", chat)\n",
+    "print(\n",
+    "    f\"  tokens_before={chat.tokens_before} tokens_after={chat.tokens_after}\"\n",
+    "    f\" tokens_saved={chat.tokens_saved} transforms_applied={chat.transforms_applied}\"\n",
+    ")\n",
     "\n",
-    "print(f\"tokens:     {result.tokens_before} -> {result.tokens_after} \"\n",
-    "      f\"({result.tokens_saved} saved, {result.savings_pct:.1f}%)\")\n",
-    "print(f\"transforms: {', '.join(result.transforms_applied) or '(none applied)'}\")\n",
-    "print(f\"messages:   {len(result.messages)} message(s) ready to send\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "c1b",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# `result.messages` is the compressed list -- send it straight to your provider.\n",
-    "# The secrets above never leave this process:\n",
-    "#   client.chat.completions.create(model=\"gpt-4o\", messages=result.messages)\n",
-    "result.messages[-1]  # the redacted version of the message above"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "m2",
-   "metadata": {},
-   "source": [
-    "## 2. Compress a raw request body\n",
+    "# The safety promise, asserted rather than described.\n",
+    "outgoing = json.dumps(chat.messages)\n",
+    "for fake_secret in (\"sk-example1234567890abcdefghijklmnop\", \"AKIAIOSFODNN7EXAMPLE\"):\n",
+    "    assert fake_secret not in outgoing\n",
+    "assert \"[REDACTED:\" in outgoing\n",
     "\n",
-    "`compress` is the bytes-first core API. Give it a whole request body — messages *and*\n",
-    "the verbose tool schema — and pick the format."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "c2",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "result = tokenfold.compress(json.dumps(PAYLOAD), format=\"OPENAI_JSON\", mode=\"BALANCED\")\n",
-    "report = result.report\n",
-    "\n",
-    "# `best_effort` here means \"no target_tokens to confirm against\", not a failure:\n",
-    "# `compressed` is reserved for runs that provably met a target you asked for.\n",
-    "print(f\"status:     {report.status}\")\n",
-    "print(f\"tokens:     {report.original_tokens} -> {report.compressed_tokens} \"\n",
-    "      f\"({report.saved_tokens} saved, {report.savings_pct:.1f}%)\")\n",
-    "print(f\"estimator:  {report.estimator.backend} (exact: {report.estimator.is_exact})\")\n",
-    "for w in report.warnings:\n",
-    "    print(f\"  warning: {w}\")\n",
-    "print(f\"payload:    {len(result.payload)} bytes\")"
+    "# `chat.messages` is provider-ready as it stands:\n",
+    "#   client.chat.completions.create(model=\"gpt-4o\", messages=chat.messages)\n",
+    "chat.messages[-1]"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "m2b",
+   "id": "providers",
    "metadata": {},
    "source": [
-    "## 3. Same, but for Anthropic-style requests\n",
+    "## 6. Complete provider request bodies\n",
     "\n",
-    "Every provider gets a matching one-liner: `compress_openai_payload` and\n",
-    "`compress_anthropic_payload` are `compress(..., format=...)` with the format\n",
-    "pre-selected. Anthropic's Messages API keeps `system` outside the `messages` array\n",
-    "and tool schemas under `input_schema` — the compressor already knows both shapes.\n",
-    "A small toolset like this one, where every tool shares the same parameter shape, is\n",
-    "close to the ceiling for this format: provider request bodies stay wire-compatible,\n",
-    "so schema compaction and whitespace removal are the whole budget — there's no\n",
-    "columnar folding here the way there is for generic JSON in the next section."
+    "When you already have the full wire payload, the provider helpers are `compress` with the\n",
+    "matching format preselected. They preserve provider wire shape, so what comes back is\n",
+    "still a valid request body.\n",
+    "\n",
+    "This is also where **protected content** becomes visible. System messages and the latest\n",
+    "user turn are protected, and their token cost forms the `protected_floor` in the budget\n",
+    "receipt. Ask for a target below that floor and tokenfold reports `UNREACHABLE_TARGET` and\n",
+    "returns the payload intact, rather than damaging protected content to hit a number."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "c2b",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 7,
+   "id": "provider-helpers",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-21T00:06:59.239628Z",
+     "iopub.status.busy": "2026-08-21T00:06:59.239628Z",
+     "iopub.status.idle": "2026-08-21T00:07:00.060554Z",
+     "shell.execute_reply": "2026-08-21T00:07:00.060554Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "OpenAI                   363 ->   213 tokens  ( 41.3% saved)  BEST_EFFORT         json_minify, schema_compaction\n",
+      "  format=openai_json  messages=4  protected_floor=32\n",
+      "Anthropic                340 ->   203 tokens  ( 40.3% saved)  BEST_EFFORT         json_minify, schema_compaction\n",
+      "  format=anthropic_json  messages=3  protected_floor=32\n"
+     ]
+    }
+   ],
    "source": [
-    "LOCATION_PARAM = {\n",
-    "    \"type\": \"string\",\n",
-    "    \"description\": \"The city and state, e.g. San Francisco, CA\",\n",
-    "    \"examples\": [\"San Francisco, CA\", \"New York, NY\", \"Austin, TX\", \"Seattle, WA\"],\n",
-    "}\n",
-    "UNIT_PARAM = {\n",
-    "    \"type\": \"string\",\n",
-    "    \"enum\": [\"celsius\", \"fahrenheit\"],\n",
-    "    \"description\": \"The unit to return the temperature in.\",\n",
-    "    \"examples\": [\"celsius\", \"fahrenheit\"],\n",
-    "}\n",
+    "openai_request = json.loads((EXAMPLES / \"openai_payload.json\").read_text(encoding=\"utf-8\"))\n",
     "\n",
-    "\n",
-    "def location_tool(name, description):\n",
-    "    return {\n",
-    "        \"name\": name,\n",
-    "        \"description\": description,\n",
-    "        \"input_schema\": {\n",
-    "            \"type\": \"object\",\n",
-    "            \"properties\": {\"location\": LOCATION_PARAM, \"unit\": UNIT_PARAM},\n",
-    "            \"required\": [\"location\"],\n",
-    "        },\n",
-    "    }\n",
-    "\n",
-    "\n",
-    "ANTHROPIC_PAYLOAD = json.dumps({\n",
+    "# A comparable Anthropic-shaped request derived from the same fixture.\n",
+    "weather_tool = openai_request[\"tools\"][0][\"function\"]\n",
+    "anthropic_request = {\n",
     "    \"model\": \"claude-sonnet-5\",\n",
-    "    \"system\": \"You are a careful senior software engineer. You write correct, minimal \"\n",
-    "              \"code and explain your reasoning briefly.\",\n",
-    "    \"messages\": [\n",
-    "        {\"role\": \"user\", \"content\": \"Can you show me the tool schemas for weather lookups?\"},\n",
-    "        {\"role\": \"assistant\", \"content\": \"Sure -- here are the weather tools available.\"},\n",
-    "        {\"role\": \"user\", \"content\": \"Great, now compress the schema and tell me what changed.\"},\n",
-    "    ],\n",
-    "    # Five tools sharing the same location/unit shape -- a realistic small toolset,\n",
-    "    # and exactly the kind of repetition schema_compaction is built to fold.\n",
+    "    \"system\": openai_request[\"messages\"][0][\"content\"],\n",
+    "    \"messages\": openai_request[\"messages\"][1:],\n",
     "    \"tools\": [\n",
-    "        location_tool(\"get_weather\", \"Look up the current weather for a given location.\"),\n",
-    "        location_tool(\"get_forecast\", \"Look up the multi-day forecast for a given location.\"),\n",
-    "        location_tool(\"get_air_quality\", \"Look up the current air quality index for a given location.\"),\n",
-    "        location_tool(\"get_uv_index\", \"Look up the current UV index for a given location.\"),\n",
-    "        location_tool(\"get_pollen_count\", \"Look up the current pollen count for a given location.\"),\n",
+    "        {\n",
+    "            \"name\": weather_tool[\"name\"],\n",
+    "            \"description\": weather_tool[\"description\"],\n",
+    "            \"input_schema\": weather_tool[\"parameters\"],\n",
+    "        }\n",
     "    ],\n",
-    "})\n",
+    "}\n",
     "\n",
-    "result = tokenfold.compress_anthropic_payload(ANTHROPIC_PAYLOAD, mode=\"BALANCED\")\n",
-    "report = result.report\n",
+    "openai_body = json.dumps(openai_request, indent=2)\n",
+    "openai_result = tokenfold.compress_openai_payload(openai_body)\n",
+    "anthropic_result = tokenfold.compress_anthropic_payload(json.dumps(anthropic_request, indent=2))\n",
     "\n",
-    "print(f\"status:     {report.status}\")\n",
-    "print(f\"tokens:     {report.original_tokens} -> {report.compressed_tokens} \"\n",
-    "      f\"({report.saved_tokens} saved, {report.savings_pct:.1f}%)\")\n",
-    "print(f\"estimator:  {report.estimator.backend} (exact: {report.estimator.is_exact})\")\n",
-    "for w in report.warnings:\n",
-    "    print(f\"  warning: {w}\")\n",
-    "print(f\"payload:    {len(result.payload)} bytes\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "m3",
-   "metadata": {},
-   "source": [
-    "## 4. Compress generic JSON data\n",
-    "\n",
-    "Not every payload is a message list. `format=\"JSON\"` compresses API responses, records,\n",
-    "and logs: repeated keys fold into columnar form, repeated values into a dictionary. Both\n",
-    "are losslessly reversible — every stage is round-trip gated before it's applied. Unlike\n",
-    "the provider formats above, this one doesn't have to stay wire-compatible with anything,\n",
-    "so it can restructure freely — a support-ticket feed like the one below, where a small\n",
-    "team rotates through many tickets, folds hard."
+    "for name, compressed in ((\"OpenAI\", openai_result), (\"Anthropic\", anthropic_result)):\n",
+    "    show(name, compressed)\n",
+    "    body = json.loads(compressed.payload)  # still wire-shaped JSON\n",
+    "    print(\n",
+    "        f\"  format={compressed.report.format}\"\n",
+    "        f\"  messages={len(body['messages'])}\"\n",
+    "        f\"  protected_floor={compressed.report.raw['budget']['protected_floor']}\"\n",
+    "    )"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "c3",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 8,
+   "id": "protected-floor",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-21T00:07:00.064573Z",
+     "iopub.status.busy": "2026-08-21T00:07:00.064573Z",
+     "iopub.status.idle": "2026-08-21T00:07:00.469458Z",
+     "shell.execute_reply": "2026-08-21T00:07:00.469458Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "below the floor          363 ->   363 tokens  (  0.0% saved)  UNREACHABLE_TARGET  (none applied)\n",
+      "  budget: {'target_tokens': 30, 'protected_floor': 32, 'achieved_tokens': 363}\n"
+     ]
+    }
+   ],
    "source": [
-    "# A support-ticket routing feed: the same 4 agents and 4 statuses recur across every\n",
-    "# ticket, and every ticket shares the same team/priority/sla_tier -- a realistic case\n",
-    "# where almost the whole payload is repeated keys and values.\n",
-    "AGENTS = [\"Ada Lovelace\", \"Alan Turing\", \"Grace Hopper\", \"Barbara Liskov\"]\n",
-    "STATUSES = [\"open\", \"in_progress\", \"resolved\", \"closed\"]\n",
-    "tickets = [\n",
-    "    {\n",
-    "        \"assigned_to\": AGENTS[i % len(AGENTS)],\n",
-    "        \"status\": STATUSES[i % len(STATUSES)],\n",
-    "        \"priority\": \"normal\",\n",
-    "        \"team\": \"platform-support\",\n",
-    "        \"sla_tier\": \"standard\",\n",
-    "    }\n",
-    "    for i in range(50)\n",
+    "# Ask for less than the protected content itself costs.\n",
+    "floor = openai_result.report.raw[\"budget\"][\"protected_floor\"]\n",
+    "impossible = tokenfold.compress_openai_payload(openai_body, target_tokens=max(1, floor - 2))\n",
+    "show(\"below the floor\", impossible)\n",
+    "print(\"  budget:\", impossible.report.raw[\"budget\"])\n",
+    "\n",
+    "assert impossible.report.status == tokenfold.Status.UNREACHABLE_TARGET\n",
+    "# Refused, not damaged: the payload comes back whole and still parses.\n",
+    "assert impossible.report.compressed_tokens == impossible.report.original_tokens\n",
+    "assert json.loads(impossible.payload) == openai_request"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "formats",
+   "metadata": {},
+   "source": [
+    "## 7. Input-format coverage at a glance\n",
+    "\n",
+    "The same core accepts more than JSON. What each format actually does from Python:\n",
+    "\n",
+    "| Input format | Notebook treatment |\n",
+    "| --- | --- |\n",
+    "| `AUTO` | Accepted, but the binding does **not** sniff: `AUTO` (and omitting `format`) leaves the report format as `auto` and applies no structural transform. Always name the format from Python — content sniffing lives in the CLI, proxy, and MCP server. |\n",
+    "| `JSON` | Fully demonstrated in sections 2-4. |\n",
+    "| `OPENAI_JSON` / `ANTHROPIC_JSON` | Fully demonstrated in section 6. |\n",
+    "| `PLAIN_TEXT` / `COMMAND_OUTPUT` | Accepted, and redaction still runs, but no non-redaction transform applies under the default Python policy: `log_compaction` is task-scope-gated and the scope knob is CLI-only (`--task-scope`), and the experimental `log_field_fold` stays out of this quickstart. For logs and command output, reach for the CLI `wrap`. |\n",
+    "| `GIT_DIFF` | Accepted; its compactor (`diff_compaction`) is experimental, so opt in through the CLI `compress --format diff` rather than here. (`tokenfold diff` is a different command — it verifies a compressed payload against its raw form.) |\n",
+    "\n",
+    "The cell below runs each row, so the routing is demonstrated rather than claimed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "format-routing",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-21T00:07:00.473556Z",
+     "iopub.status.busy": "2026-08-21T00:07:00.473556Z",
+     "iopub.status.idle": "2026-08-21T00:07:02.606136Z",
+     "shell.execute_reply": "2026-08-21T00:07:02.605132Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[{'input': 'bundled JSON',\n",
+       "  'requested': 'AUTO',\n",
+       "  'report format': 'auto',\n",
+       "  'tokens': '3812 -> 3812',\n",
+       "  'applied': '(none applied)'},\n",
+       " {'input': 'bundled JSON',\n",
+       "  'requested': 'JSON',\n",
+       "  'report format': 'json',\n",
+       "  'tokens': '3812 -> 1376',\n",
+       "  'applied': 'json_minify, json_field_fold, json_value_dict'},\n",
+       " {'input': 'log lines',\n",
+       "  'requested': 'PLAIN_TEXT',\n",
+       "  'report format': 'plain_text',\n",
+       "  'tokens': '231 -> 231',\n",
+       "  'applied': '(none applied)'},\n",
+       " {'input': 'command output',\n",
+       "  'requested': 'COMMAND_OUTPUT',\n",
+       "  'report format': 'command_output',\n",
+       "  'tokens': '231 -> 231',\n",
+       "  'applied': '(none applied)'},\n",
+       " {'input': 'git diff',\n",
+       "  'requested': 'GIT_DIFF',\n",
+       "  'report format': 'git_diff',\n",
+       "  'tokens': '43 -> 43',\n",
+       "  'applied': '(none applied)'}]"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "log_lines = \"\\n\".join(\n",
+    "    f\"2026-08-15T00:0{i}:11Z INFO worker-{i % 3} processed batch id=b{i} rows=120 ms=45\"\n",
+    "    for i in range(8)\n",
+    ")\n",
+    "git_diff = (\n",
+    "    \"diff --git a/app.py b/app.py\\n\"\n",
+    "    \"--- a/app.py\\n\"\n",
+    "    \"+++ b/app.py\\n\"\n",
+    "    \"@@ -1,2 +1,2 @@\\n\"\n",
+    "    \"-timeout = 30\\n\"\n",
+    "    \"+timeout = 60\\n\"\n",
+    ")\n",
+    "\n",
+    "routing = []\n",
+    "for label, payload, input_format in (\n",
+    "    (\"bundled JSON\", source, tokenfold.InputFormat.AUTO),\n",
+    "    (\"bundled JSON\", source, tokenfold.InputFormat.JSON),\n",
+    "    (\"log lines\", log_lines, tokenfold.InputFormat.PLAIN_TEXT),\n",
+    "    (\"command output\", log_lines, tokenfold.InputFormat.COMMAND_OUTPUT),\n",
+    "    (\"git diff\", git_diff, tokenfold.InputFormat.GIT_DIFF),\n",
+    "):\n",
+    "    routed = tokenfold.inspect(payload, format=input_format)\n",
+    "    applied = [t[\"id\"] for t in routed.report.raw[\"transforms\"] if t[\"status\"] == \"applied\"]\n",
+    "    routing.append(\n",
+    "        {\n",
+    "            \"input\": label,\n",
+    "            \"requested\": str(input_format).replace(\"InputFormat.\", \"\"),\n",
+    "            \"report format\": routed.report.format,\n",
+    "            \"tokens\": f\"{routed.report.original_tokens} -> {routed.report.compressed_tokens}\",\n",
+    "            \"applied\": \", \".join(applied) or \"(none applied)\",\n",
+    "        }\n",
+    "    )\n",
+    "\n",
+    "routing"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "lossy",
+   "metadata": {},
+   "source": [
+    "## 8. Recoverable lossy pruning\n",
+    "\n",
+    "Everything above stays on the lossless structural path (safety redaction may still have\n",
+    "replaced detected secrets — that is protection, not compression). This section is the\n",
+    "opt-in lossy *selection* path. When the lossless floor is not low enough — heterogeneous\n",
+    "arrays of long, mostly-routine records are the classic case — lossy pruning replaces\n",
+    "lower-value rows with `{\"$tf_ref\": ...}` retrieval markers. It is opt-in, generic-JSON\n",
+    "only, and fail-closed: a row leaves the payload only after its original bytes are stored\n",
+    "durably, so every marker resolves.\n",
+    "\n",
+    "The fixture is a 40-row incident feed with one planted high-signal row\n",
+    "(`event == \"incident\"`). Two things set the savings ceiling: each marker costs roughly 35\n",
+    "tokens, so long rows amortize it best, and `lossy_ratio` is the dial — it is the fraction\n",
+    "of rows to keep, so a lower value prunes more. The 100-row showcase in\n",
+    "`lossy_pruning.py` reaches 91.7% the same way. Four steps follow, all inside a temporary\n",
+    "directory so `Restart & Run All` stays idempotent and your real retrieval store is never\n",
+    "touched:\n",
+    "\n",
+    "1. **Preview** — `inspect` projects the saving and still returns your input byte for byte.\n",
+    "   It deliberately claims nothing about persistence: `raw[\"retrieval\"]` stays `None` and no\n",
+    "   `$tf_ref` marker appears, because a preview stores nothing.\n",
+    "2. **Compress** — the real run emits markers and a retrieval receipt, then a second run\n",
+    "   turns the dial to `lossy_ratio=0.05` to show the ceiling: one row of forty stays\n",
+    "   inline, and it is the incident. The assertions check invariants, not counts: the\n",
+    "   heuristic's exact split moves between versions, so what matters is that every original\n",
+    "   row is either inline or retrievable and that the incident row stayed inline at every\n",
+    "   ratio. (Receipt detail: `marker_count` counts one whole-payload evidence entry on top\n",
+    "   of the row markers.)\n",
+    "3. **Retrieve** — fetch one omitted row by hash and namespace and check it round-trips.\n",
+    "   `retrieve` raises `RetrievalError` (a `TokenFoldError`) for a missing or expired hash.\n",
+    "4. **Preserve** — `lossy_preserve=[\"events\"]` protects a path outright: no markers at\n",
+    "   all. Its savings fall back toward the lossless floor by design — that run is the\n",
+    "   protection demo, not the compression demo.\n",
+    "\n",
+    "The measured saving is a token number, not a fidelity claim. The heuristic path reports\n",
+    "itself as `unvalidated` in the receipt's quality block, and it says so honestly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "lossy-preview",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-21T00:07:02.609136Z",
+     "iopub.status.busy": "2026-08-21T00:07:02.609136Z",
+     "iopub.status.idle": "2026-08-21T00:07:03.680513Z",
+     "shell.execute_reply": "2026-08-21T00:07:03.679509Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "40 rows, 1 high-signal incident row(s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "lossy preview          7,216 -> 3,485 tokens  ( 51.7% saved)  BEST_EFFORT         json_minify, json_prune\n"
+     ]
+    }
+   ],
+   "source": [
+    "incident_source = (EXAMPLES / \"incident_feed.json\").read_text(encoding=\"utf-8\")\n",
+    "original_events = json.loads(incident_source)[\"events\"]\n",
+    "print(\n",
+    "    f\"{len(original_events)} rows,\"\n",
+    "    f\" {sum(1 for e in original_events if e['event'] == 'incident')} high-signal incident row(s)\"\n",
+    ")\n",
+    "\n",
+    "store = tempfile.TemporaryDirectory()  # removed at the end of this section\n",
+    "lossy_policy = tokenfold.CompressionPolicy(\n",
+    "    mode=tokenfold.CompressionMode.BALANCED,\n",
+    "    retrieval_backend=\"filesystem\",\n",
+    "    retrieval_store_path=store.name,\n",
+    "    lossy=tokenfold.LossyPath.HEURISTIC,\n",
+    "    lossy_ratio=0.35,\n",
+    ")\n",
+    "\n",
+    "lossy_preview = tokenfold.inspect(\n",
+    "    incident_source, policy=lossy_policy, format=tokenfold.InputFormat.JSON\n",
+    ")\n",
+    "show(\"lossy preview\", lossy_preview)\n",
+    "\n",
+    "assert lossy_preview.payload == incident_source.encode(\"utf-8\")\n",
+    "assert lossy_preview.report.raw[\"retrieval\"] is None  # a preview persists nothing"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "lossy-compress",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-21T00:07:03.683513Z",
+     "iopub.status.busy": "2026-08-21T00:07:03.683513Z",
+     "iopub.status.idle": "2026-08-21T00:07:05.653050Z",
+     "shell.execute_reply": "2026-08-21T00:07:05.652047Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "lossy compress         7,216 -> 3,485 tokens  ( 51.7% saved)  BEST_EFFORT         json_minify, json_prune\n",
+      "  13 rows inline, 27 replaced by retrieval markers\n",
+      "  retrieval: {'store_namespace': 'default', 'hash_algorithm': 'sha256', 'marker_count': 28, 'ttl_seconds': 604800, 'persisted_original_bytes': 46592, 'skipped_original_bytes': 0}\n",
+      "  quality:   {'eval_profile_id': 'unvalidated', 'task_scope': 'all', 'validated_ratio_band': None, 'quality_retention': None, 'contrastive_failure_rate': None, 'gate_passed': False}\n",
+      "dial at 0.05           7,216 -> 2,294 tokens  ( 68.2% saved)  BEST_EFFORT         json_minify, json_prune\n",
+      "  1 of 40 rows kept inline\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "{'hash': 'cb13cc59cca0c218c579cd1d4b3cbab58d6dea265eb995cc9c00faf0cd0a6856',\n",
+       " 'alg': 'sha256',\n",
+       " 'namespace': 'default'}"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "lossy_result = tokenfold.compress(\n",
+    "    incident_source, policy=lossy_policy, format=tokenfold.InputFormat.JSON\n",
+    ")\n",
+    "show(\"lossy compress\", lossy_result)\n",
+    "\n",
+    "events = json.loads(lossy_result.payload)[\"events\"]\n",
+    "markers = [event[\"$tf_ref\"] for event in events if \"$tf_ref\" in event]\n",
+    "inline = [event for event in events if \"$tf_ref\" not in event]\n",
+    "\n",
+    "assert markers, \"expected at least one retrieval marker\"\n",
+    "assert len(inline) + len(markers) == len(original_events)  # every row accounted for\n",
+    "assert any(event[\"event\"] == \"incident\" for event in inline)  # the planted row survived\n",
+    "\n",
+    "print(f\"  {len(inline)} rows inline, {len(markers)} replaced by retrieval markers\")\n",
+    "print(\"  retrieval:\", lossy_result.report.raw[\"retrieval\"])\n",
+    "print(\"  quality:  \", lossy_result.report.raw[\"quality\"])\n",
+    "\n",
+    "# The dial: lossy_ratio is the fraction of rows to keep. Turn it down and savings climb —\n",
+    "# and the last row standing is the incident, because typed failure signals outrank\n",
+    "# position and length in the ranking.\n",
+    "tight_lossy = tokenfold.compress(\n",
+    "    incident_source,\n",
+    "    policy=lossy_policy,\n",
+    "    format=tokenfold.InputFormat.JSON,\n",
+    "    lossy_ratio=0.05,\n",
+    ")\n",
+    "show(\"dial at 0.05\", tight_lossy)\n",
+    "tight_inline = [e for e in json.loads(tight_lossy.payload)[\"events\"] if \"$tf_ref\" not in e]\n",
+    "print(f\"  {len(tight_inline)} of {len(original_events)} rows kept inline\")\n",
+    "assert any(event[\"event\"] == \"incident\" for event in tight_inline)\n",
+    "markers[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "lossy-retrieve",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-21T00:07:05.656051Z",
+     "iopub.status.busy": "2026-08-21T00:07:05.656051Z",
+     "iopub.status.idle": "2026-08-21T00:07:06.248082Z",
+     "shell.execute_reply": "2026-08-21T00:07:06.247077Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "preserved (no pruning) 7,216 -> 6,144 tokens  ( 14.9% saved)  BEST_EFFORT         json_minify\n",
+      "  savings fall back toward the lossless floor: protection wins over compression\n",
+      "  recovered row seq=1 event=cache\n"
+     ]
+    }
+   ],
+   "source": [
+    "marker = markers[0]\n",
+    "restored = json.loads(\n",
+    "    tokenfold.retrieve(marker[\"hash\"], namespace=marker[\"namespace\"], policy=lossy_policy)\n",
+    ")\n",
+    "assert restored in original_events  # exactly the row that left the payload\n",
+    "\n",
+    "# Same policy, one protected path: nothing in `events` may be pruned.\n",
+    "preserving_policy = tokenfold.CompressionPolicy(\n",
+    "    mode=tokenfold.CompressionMode.BALANCED,\n",
+    "    retrieval_backend=\"filesystem\",\n",
+    "    retrieval_store_path=store.name,\n",
+    "    lossy=tokenfold.LossyPath.HEURISTIC,\n",
+    "    lossy_ratio=0.35,\n",
+    "    lossy_preserve=[\"events\"],\n",
+    ")\n",
+    "preserved = tokenfold.compress(\n",
+    "    incident_source, policy=preserving_policy, format=tokenfold.InputFormat.JSON\n",
+    ")\n",
+    "show(\"preserved (no pruning)\", preserved)\n",
+    "print(\"  savings fall back toward the lossless floor: protection wins over compression\")\n",
+    "assert not [\n",
+    "    event for event in json.loads(preserved.payload)[\"events\"] if \"$tf_ref\" in event\n",
     "]\n",
-    "data = json.dumps({\"status\": \"ok\", \"count\": len(tickets), \"tickets\": tickets})\n",
     "\n",
-    "result = tokenfold.compress(data, format=\"JSON\", mode=\"BALANCED\")\n",
-    "report = result.report\n",
-    "\n",
-    "applied = [t[\"id\"] for t in report.raw[\"transforms\"] if t[\"status\"] == \"applied\"]\n",
-    "print(f\"tokens:     {report.original_tokens} -> {report.compressed_tokens} \"\n",
-    "      f\"({report.saved_tokens} saved, {report.savings_pct:.1f}%)\")\n",
-    "print(f\"transforms: {', '.join(applied)}\")\n",
-    "print(f\"bytes:      {len(data)} -> {len(result.payload)}\")"
+    "store.cleanup()  # nothing left on disk\n",
+    "print(f\"  recovered row seq={restored['seq']} event={restored['event']}\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "m3b",
+   "id": "select",
    "metadata": {},
    "source": [
-    "## 5. Preview without compressing (dry run)\n",
+    "## 9. Tokenfold Select: optional fine-tuned ranking\n",
     "\n",
-    "`inspect` runs the same safety checks and reports what *would* happen, but hands your\n",
-    "bytes back untouched — use it to decide whether compressing is worth it before you\n",
-    "commit to it."
+    "**When structural compression ends and the remaining context still exceeds the budget, the\n",
+    "question stops being \"what folds?\" and becomes \"what matters for this query?\"**\n",
+    "\n",
+    "[Tokenfold Select](https://huggingface.co/snchimata/tokenfold-select) is an Apache-2.0\n",
+    "LoRA adapter on\n",
+    "[`ibm-granite/granite-embedding-reranker-english-r2`](https://huggingface.co/ibm-granite/granite-embedding-reranker-english-r2).\n",
+    "It jointly scores each `(query, span)` pair and returns one ranking logit per span. It is a\n",
+    "**ranker** — not a compressor, not an allocator, and not a safety filter — and its logits\n",
+    "are not probabilities.\n",
+    "\n",
+    "| | Tokenfold Core | Tokenfold Select |\n",
+    "| --- | --- | --- |\n",
+    "| Best at | Deterministic structural compression | Query-conditioned span ranking |\n",
+    "| Runtime | Rust core / Python binding | Granite reranker plus LoRA adapter |\n",
+    "| Output | Compressed payload plus exact receipt | One ranking logit per span |\n",
+    "\n",
+    "The intended composition is a pipeline: run deterministic Core compression first, segment\n",
+    "what remains into candidate spans, use Select to order the eligible spans, then let a\n",
+    "separate allocator force-keep required content and enforce the exact token budget.\n",
+    "\n",
+    "### Published held-out results\n",
+    "\n",
+    "Task success is the fraction of fixtures whose literal gold-answer span survives the\n",
+    "matched allocator budget. Values are means over three stratified repeated-subsampling\n",
+    "runs, with roughly 24,000 held-out fixtures per run.\n",
+    "\n",
+    "| Token budget kept | Tokenfold Select | BM25 | Relative lift over BM25 |\n",
+    "| ---: | ---: | ---: | ---: |\n",
+    "| 50% | 86.3% | 79.4% | 8.7% |\n",
+    "| 25% | 70.3% | 60.7% | 15.8% |\n",
+    "| 10% | 39.9% | 37.7% | 5.8% |\n",
+    "\n",
+    "### Limitations\n",
+    "\n",
+    "- Select is a separate PyTorch/Transformers runtime. It is **not** a function exported by\n",
+    "  the `tokenfold` Python package, and the adapter repository does not contain the Granite\n",
+    "  base weights — that is a second download.\n",
+    "- Evaluation is English-centric, and each `(query, span)` pair is truncated at 8,192 tokens.\n",
+    "- Logits are uncalibrated: compare them within one query, never across queries.\n",
+    "- Ranking alone guarantees nothing about required or safety-critical text surviving. Your\n",
+    "  allocator must force-keep it and enforce the provider budget.\n",
+    "\n",
+    "The cell below is **disabled by default** and imports and downloads nothing until you\n",
+    "change the flag yourself. See the\n",
+    "[model card](https://huggingface.co/snchimata/tokenfold-select) for the full training,\n",
+    "evaluation, and licensing details."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "c3b",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 13,
+   "id": "select-scoring",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-21T00:07:06.251082Z",
+     "iopub.status.busy": "2026-08-21T00:07:06.251082Z",
+     "iopub.status.idle": "2026-08-21T00:07:06.257211Z",
+     "shell.execute_reply": "2026-08-21T00:07:06.256082Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Tokenfold Select is off by default: nothing imported, nothing downloaded.\n",
+      "To enable:  pip install torch transformers peft huggingface_hub\n",
+      "Model card: https://huggingface.co/snchimata/tokenfold-select\n"
+     ]
+    }
+   ],
    "source": [
-    "preview = tokenfold.inspect(data, format=\"JSON\", mode=\"BALANCED\")\n",
-    "preview_report = preview.report\n",
+    "RUN_TOKENFOLD_SELECT = False  # set to True to download the model weights and score locally\n",
     "\n",
-    "would_apply = [t[\"id\"] for t in preview_report.raw[\"transforms\"] if t[\"status\"] == \"applied\"]\n",
-    "print(f\"would apply: {', '.join(would_apply)}\")\n",
-    "print(f\"projected:   {preview_report.original_tokens} -> {preview_report.compressed_tokens} \"\n",
-    "      f\"({preview_report.saved_tokens} saved, {preview_report.savings_pct:.1f}%)\")\n",
-    "print(f\"payload:     {len(preview.payload)} bytes -- your input, handed back unchanged\")\n",
-    "assert preview.payload == data.encode(\"utf-8\"), \"inspect() must never modify the input\""
+    "if not RUN_TOKENFOLD_SELECT:\n",
+    "    print(\"Tokenfold Select is off by default: nothing imported, nothing downloaded.\")\n",
+    "    print(\"To enable:  pip install torch transformers peft huggingface_hub\")\n",
+    "    print(\"Model card: https://huggingface.co/snchimata/tokenfold-select\")\n",
+    "else:\n",
+    "    import math\n",
+    "\n",
+    "    import torch\n",
+    "    from huggingface_hub import snapshot_download\n",
+    "    from peft import PeftModel\n",
+    "    from transformers import AutoModelForSequenceClassification, AutoTokenizer\n",
+    "\n",
+    "    # Three short spans straight from the section-8 fixture, loaded here so this cell\n",
+    "    # does not depend on earlier notebook state.\n",
+    "    feed = json.loads((EXAMPLES / \"incident_feed.json\").read_text(encoding=\"utf-8\"))\n",
+    "    events = feed[\"events\"]\n",
+    "    query = \"why did the object-store writer fail?\"\n",
+    "    spans = [\n",
+    "        event[\"detail\"]\n",
+    "        for event in (\n",
+    "            next(e for e in events if e[\"event\"] == \"incident\"),\n",
+    "            events[0],\n",
+    "            events[1],\n",
+    "        )\n",
+    "    ]\n",
+    "\n",
+    "    repo_dir = Path(snapshot_download(\"snchimata/tokenfold-select\"))\n",
+    "    adapter_dir = repo_dir / \"adapter\"\n",
+    "    tokenizer = AutoTokenizer.from_pretrained(adapter_dir)\n",
+    "    base = AutoModelForSequenceClassification.from_pretrained(\n",
+    "        \"ibm-granite/granite-embedding-reranker-english-r2\",\n",
+    "        dtype=torch.float32,\n",
+    "    )\n",
+    "    model = PeftModel.from_pretrained(base, adapter_dir).eval()\n",
+    "\n",
+    "    encoded = tokenizer(\n",
+    "        [query] * len(spans),\n",
+    "        spans,\n",
+    "        padding=True,\n",
+    "        truncation=True,\n",
+    "        max_length=8192,\n",
+    "        return_tensors=\"pt\",\n",
+    "    )\n",
+    "    with torch.no_grad():\n",
+    "        logits = model(\n",
+    "            input_ids=encoded[\"input_ids\"],\n",
+    "            attention_mask=encoded[\"attention_mask\"],\n",
+    "        ).logits\n",
+    "    scores = logits.view(-1).float().tolist()\n",
+    "\n",
+    "    # One finite score per span is the contract; exact values and order are not.\n",
+    "    assert len(scores) == len(spans)\n",
+    "    assert all(math.isfinite(score) for score in scores)\n",
+    "\n",
+    "    print(f\"query: {query}\\n\")\n",
+    "    for score, span in sorted(zip(scores, spans), key=lambda pair: -pair[0]):\n",
+    "        print(f\"{score:8.3f}  {span[:88]}...\")\n",
+    "    print(\"\\nSorting is not allocation: a real consumer must force-keep required spans\")\n",
+    "    print(\"and enforce the provider token budget separately.\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "m4",
+   "id": "next",
    "metadata": {},
    "source": [
-    "## 6. Read the whole receipt\n",
+    "## 10. Where to go next\n",
     "\n",
-    "tokenfold never silently drops content — you get receipts. The promoted attributes above\n",
-    "are a subset; `report.raw` is the full report as a plain dict, which is where `quality`,\n",
-    "`budget`, `cache`, `retrieval`, and the per-transform breakdown live."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "c4",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "row = \"{:<18} {:<10} {:>7} {:>7} {:>7}\"\n",
-    "print(row.format(\"TRANSFORM\", \"STATUS\", \"BEFORE\", \"AFTER\", \"SAVED\"))\n",
-    "for t in report.raw[\"transforms\"]:\n",
-    "    print(row.format(t[\"id\"], t[\"status\"], t[\"tokens_before\"], t[\"tokens_after\"], t[\"saved_tokens\"]))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "c5",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Everything the transform table leaves out:\n",
-    "{k: v for k, v in report.raw.items() if k != \"transforms\"}"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "m5",
-   "metadata": {},
-   "source": [
-    "## Where to next\n",
+    "| Need | Next surface |\n",
+    "| --- | --- |\n",
+    "| Files, stdin, diffs, or command output | CLI: `compress` (incl. `--format diff`), `inspect`, `wrap` |\n",
+    "| Verify a compressed payload against its raw form | CLI: `diff` |\n",
+    "| Retrieval and realized-savings operations | CLI: `retrieve`, `stats`, `gain`, `session`, `output-savings` |\n",
+    "| Agent/editor tools | `tokenfold mcp serve` for MCP and `doctor` for diagnostics; `init`/`uninit` exist, but no host integration is supported yet |\n",
+    "| Transparent provider traffic | `tokenfold-proxy` |\n",
+    "| Plain-script version of this tour | [`quickstart.py`](quickstart.py) |\n",
+    "| Node application | [`quickstart.mjs`](quickstart.mjs) |\n",
+    "| Native embedding | `tokenfold-core` and [`quickstart.rs`](quickstart.rs) |\n",
+    "| Deeper pruning behavior | [`lossy_pruning.py`](lossy_pruning.py) |\n",
+    "| Query-aware learned ranking | Section 9 and the [Tokenfold Select model card](https://huggingface.co/snchimata/tokenfold-select) |\n",
     "\n",
-    "- [`quickstart.py`](quickstart.py) — the same three operations as a plain script\n",
-    "- [`quickstart.mjs`](quickstart.mjs) — the TypeScript/Node package\n",
-    "- [`quickstart.rs`](quickstart.rs) — the embedded Rust core API\n",
-    "- [`lossy_pruning.py`](lossy_pruning.py) — opt-in recoverable pruning, CLI-driven"
+    "### Which path is yours?\n",
+    "\n",
+    "1. **Start with `inspect`** on a payload representative of your real traffic. It costs\n",
+    "   nothing and shows you where the lossless floor is.\n",
+    "2. **Use ordinary `compress`** when that lossless saving is enough. Most JSON and provider\n",
+    "   traffic stops here.\n",
+    "3. **Add a durable retrieval policy and lossy pruning** only when the lossless floor is\n",
+    "   not low enough, and keep preserve paths on anything you cannot afford to lose.\n",
+    "4. **Reach for Tokenfold Select** when what is left is a question of query-conditioned\n",
+    "   relevance — with a separate allocator force-keeping required content and enforcing the\n",
+    "   exact budget."
    ]
   }
  ],

--- a/packages/tokenfold/package-lock.json
+++ b/packages/tokenfold/package-lock.json
@@ -27,19 +27,84 @@
       }
     },
     "node_modules/@tokenfold/cli-darwin-arm64": {
-      "optional": true
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@tokenfold/cli-darwin-arm64/-/cli-darwin-arm64-0.4.1.tgz",
+      "integrity": "sha512-WH71IQDWTXH85qNAQ/b+K5LdSUj1bx7F7auJizlYKk1HA2/JbO0S2ykKfXO8LTYoQxKVR6IUMeYrP5hm5w/8wg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=22"
+      }
     },
     "node_modules/@tokenfold/cli-darwin-x64": {
-      "optional": true
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@tokenfold/cli-darwin-x64/-/cli-darwin-x64-0.4.1.tgz",
+      "integrity": "sha512-r8kCelCrzmrJCZCwTROehHEmLYEJJH3JrthFE2OhgbdXqmf9tcMt7qlFotYBsXCAPVVCKatk+A15tXFm+QCDIw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=22"
+      }
     },
     "node_modules/@tokenfold/cli-linux-arm64": {
-      "optional": true
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@tokenfold/cli-linux-arm64/-/cli-linux-arm64-0.4.1.tgz",
+      "integrity": "sha512-uXQ7nqGFKV5KkbAE85nELN584dxIB0Qv4R5vIbpajkvk5+qkegzLofZkSq8gUfOMXxa/yefnXipktV/ZiHXEFw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=22"
+      }
     },
     "node_modules/@tokenfold/cli-linux-x64": {
-      "optional": true
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@tokenfold/cli-linux-x64/-/cli-linux-x64-0.4.1.tgz",
+      "integrity": "sha512-cdlwWkp4yIKO2UswoVMV5lGoXU/7xmGOjHf1Uwfm2BbRz0TSD2x6EbhamFwsTwNg4BysIVxF9WB13AgVOXIaoQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=22"
+      }
     },
     "node_modules/@tokenfold/cli-win32-x64": {
-      "optional": true
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@tokenfold/cli-win32-x64/-/cli-win32-x64-0.4.1.tgz",
+      "integrity": "sha512-lFNjLQ/fxvHtMjB4NYXVCZts/Ekm1hovuTpeIOAzSq/6zD94dpgn+8MSYjhRjt06GAI8nVfDGyqqgsj6/EJG8g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=22"
+      }
     },
     "node_modules/@types/node": {
       "version": "24.13.3",

--- a/python-tests/test_readme_claims.py
+++ b/python-tests/test_readme_claims.py
@@ -1,0 +1,97 @@
+"""Keeps README.md's fixture-backed compression claim honest.
+
+The README publishes the exact token counts the bundled API-response fixture
+compresses to. Fixture edits and transform changes both move that number, so this
+test re-measures it with the installed binding and fails on drift. It skips when
+the repository files are absent (e.g. a wheel-only test run), because then there
+is no claim to check.
+"""
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+import tokenfold
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README = REPO_ROOT / "README.md"
+FIXTURE = REPO_ROOT / "examples" / "api_response.json"
+
+CLAIM = re.compile(
+    r"The bundled (\d+)-record API response reports ([\d,]+) → ([\d,]+) tokens,\s+"
+    r"a \*\*([\d.]+)%",
+)
+
+
+def test_readme_fixture_claim_matches_measurement():
+    if not (README.is_file() and FIXTURE.is_file()):
+        pytest.skip("repository files not present; nothing to check")
+    match = CLAIM.search(README.read_text(encoding="utf-8"))
+    if match is None:
+        pytest.skip("README no longer publishes the fixture claim")
+
+    source = FIXTURE.read_text(encoding="utf-8")
+    report = tokenfold.compress(source, format=tokenfold.InputFormat.JSON).report
+
+    claimed = {
+        "records": int(match.group(1)),
+        "original": int(match.group(2).replace(",", "")),
+        "compressed": int(match.group(3).replace(",", "")),
+        "pct": float(match.group(4)),
+    }
+    measured = {
+        "records": len(json.loads(source)["results"]),
+        "original": report.original_tokens,
+        "compressed": report.compressed_tokens,
+        "pct": round(report.savings_pct, 1),
+    }
+    assert claimed == measured, (
+        f"README claim {claimed} no longer matches measurement {measured}; "
+        "update README.md (and re-run examples/quickstart.ipynb) in this change"
+    )
+
+
+INCIDENT_FIXTURE = REPO_ROOT / "examples" / "incident_feed.json"
+
+INCIDENT_ROW = re.compile(
+    r"\| (?:Lossless|`--lossy-ratio (0\.\d+)`) \| ([\d,]+) \| \*{0,2}([\d.]+)%\*{0,2} "
+    r"\| ([\d,]+) \|"
+)
+
+
+def test_readme_incident_table_matches_measurement(tmp_path):
+    if not (README.is_file() and INCIDENT_FIXTURE.is_file()):
+        pytest.skip("repository files not present; nothing to check")
+    claimed = INCIDENT_ROW.findall(README.read_text(encoding="utf-8"))
+    if not claimed:
+        pytest.skip("README no longer publishes the incident-feed table")
+
+    source = INCIDENT_FIXTURE.read_text(encoding="utf-8")
+    measured = []
+    for ratio, *_ in claimed:
+        if not ratio:  # the Lossless row
+            report = tokenfold.compress(source, format=tokenfold.InputFormat.JSON).report
+            kept = len(json.loads(source)["events"])
+        else:
+            policy = tokenfold.CompressionPolicy(
+                retrieval_backend="filesystem",
+                retrieval_store_path=str(tmp_path / ratio),
+                lossy=tokenfold.LossyPath.HEURISTIC,
+                lossy_ratio=float(ratio),
+            )
+            result = tokenfold.compress(
+                source, policy=policy, format=tokenfold.InputFormat.JSON
+            )
+            report = result.report
+            kept = sum(
+                1 for e in json.loads(result.payload)["events"] if "$tf_ref" not in e
+            )
+        measured.append(
+            (ratio, f"{report.compressed_tokens:,}", f"{report.savings_pct:.1f}", f"{kept}")
+        )
+    assert claimed == measured, (
+        f"README incident-feed table {claimed} no longer matches measurement {measured}; "
+        "update README.md (and re-run examples/quickstart.ipynb) in this change"
+    )


### PR DESCRIPTION
## What changed

- **Regenerated fixtures.** `examples/api_response.json` is now a 30-record fixture; `examples/incident_feed.json` is regenerated with the planted incident intact.
- **README numbers re-measured.** Inspect claim: 3,812 -> 1,376 tokens (63.9% lossless). Lossy table: 6,144/14.9% lossless, 3,485/51.7% at ratio 0.35, 2,294/68.2% at ratio 0.05 (the planted incident is the only surviving row). Retrieve example hash updated. The comparison table''s stale 61.3% cell now matches at 63.9%.
- **Notebook expanded.** `examples/quickstart.ipynb` is now a guided tour of the whole Python surface: previews, budgets and modes, provider payloads, recoverable pruning with retrieval, and Tokenfold Select.
- **Claims pinned by tests.** `python-tests/test_readme_claims.py` re-measures the README fixture claim and the incident table with the installed binding and fails on drift.
- **Community files.** Contributor Covenant 2.1 `CODE_OF_CONDUCT.md`, linked from `CONTRIBUTING.md`; `.vscode/` added to `.gitignore`.

## Verification

- `pytest python-tests`: 36 passed, 0 skipped (both new README-claims tests ran).
- Every published number was reproduced with the 0.4.1 CLI/binding: the incident table cell-by-cell (including only-survivor at ratio 0.05), the retrieve hash resolving to the seq-1 index-writer row, the 63.9% inspect claim, and the 91.7% / 84,032 -> 6,951 showcase via `examples/lossy_pruning.py`.
- Notebook outputs, README, and live measurement are mutually consistent; fixtures contain only synthetic data.