### PR TITLE
fix: address reliability and release gaps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,14 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo test --workspace --locked
 
+  windows-smoke:
+    name: windows-smoke
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo test -p tokenfold-cli -p tokenfold-proxy --locked
+
   python-wheel:
     name: python-wheel (Python 3.12)
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,44 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo test --workspace --locked
 
+  python-wheel:
+    name: python-wheel (Python 3.12)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - uses: PyO3/maturin-action@v1
+        with:
+          args: --release --locked --out dist -m crates/tokenfold-py/Cargo.toml
+          manylinux: auto
+      - run: python -m pip install pytest dist/*.whl
+      - run: python -m pytest python-tests -q
+      - uses: actions/upload-artifact@v7
+        with:
+          name: python-abi3-wheel
+          path: dist/*.whl
+          if-no-files-found: error
+
+  python-abi3-smoke:
+    name: python-abi3-smoke (Python ${{ matrix.python }})
+    needs: python-wheel
+    strategy:
+      matrix:
+        python: ["3.9", "3.13"]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python }}
+      - uses: actions/download-artifact@v8
+        with:
+          name: python-abi3-wheel
+          path: dist
+      - run: python -m pip install dist/*.whl
+      - run: python -c "import tokenfold; assert tokenfold.CompressionMode.BALANCED"
+
   node-api:
     name: node-api (Node ${{ matrix.node }})
     strategy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+- Make filesystem retrieval publication atomic across `store`, `retrieve`, and `gc`; lossy
+  candidate batches now commit completely or remain inline, and rollback restores only the
+  generated marker location.
+- Serve proxy requests with a bounded worker pool so a held-open SSE response does not block
+  health checks or other requests.
+- Cache the immutable tiktoken estimator, add Python wheel testing to pull-request CI, and pin
+  README metric provenance.
+
 ## [0.4.1] - 2026-08-18
 
 - **Python: opt-in lossy JSON pruning is now reachable from the binding**, previously

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@
   health checks or other requests.
 - Cache the immutable tiktoken estimator, add Python wheel testing to pull-request CI, and pin
   README metric provenance.
+- Parse raw hashes, legacy markers, and JSON `$tf_ref` markers through one validated retrieval
+  path across Core, CLI, proxy, MCP, Python, and TypeScript; MCP retrieval now accepts an explicit
+  namespace, and MCP compression rejects unsupported `store_originals=true` instead of ignoring it.
+- Add focused Windows CLI/proxy CI, private vulnerability-reporting guidance, and explicit
+  semantic-quality limitations. Reserved `cache_boundary` values now fail clearly instead of
+  behaving as a no-op.
 
 ## [0.4.1] - 2026-08-18
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,23 @@ git switch main && git pull
 git tag -a v0.4.1 -m "v0.4.1" && git push origin v0.4.1   # fires release.yml
 # wait for the GitHub Release to exist, then:
 gh workflow run publish-packages.yml -f version=0.4.1
+
+# After the workflow succeeds, verify every registry artifact (replace VERSION).
+VERSION=0.4.1
+for crate in tokenfold-core tokenfold-output tokenfold-learn tokenfold-cli; do
+  path="${crate:0:2}/${crate:2:2}/$crate"
+  curl -sS "https://index.crates.io/$path" | jq -e --arg v "$VERSION" 'select(.vers == $v)' >/dev/null
+done
+curl -sS https://pypi.org/pypi/tokenfold/json | jq -e --arg v "$VERSION" '.releases[$v] | length > 0' >/dev/null
+for package in tokenfold @tokenfold/cli-darwin-x64 @tokenfold/cli-darwin-arm64 @tokenfold/cli-linux-x64 @tokenfold/cli-linux-arm64 @tokenfold/cli-win32-x64; do
+  encoded=${package/\//%2f}
+  test "$(curl -sS "https://registry.npmjs.org/$encoded" | jq -r '.["dist-tags"].latest')" = "$VERSION"
+done
 ```
+
+Use the sparse crates.io index above rather than its JSON API: the JSON API
+requires a policy-compliant `User-Agent` and may return HTTP 200 with an error
+body to a bare `curl`, which can look like a missing release.
 
 Release tags are protected against deletion and force-moves: a published tag is
 immutable, because `publish-packages.yml` builds registry artifacts from the

--- a/README.md
+++ b/README.md
@@ -302,6 +302,12 @@ training data, and limitations.
 - **Local control:** detected secrets are redacted before reports or storage;
   policy learning changes configuration only with `--apply`.
 
+The offline fidelity gate uses deterministic lexical-overlap, critical-token,
+and containment proxies. Those checks catch regressions but do not establish
+semantic equivalence or downstream task success. Runtime `quality` fields are
+absent unless a versioned evaluator has supplied data; applications should run
+their own representative task evaluation before enabling lossy pruning.
+
 ## Reproduce the results
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -29,11 +29,14 @@ CLI · Python · TypeScript · Rust · proxy · MCP · local-first · provider-n
 All four use exact `o200k_base` counts in balanced mode. The 91.7% showcase
 keeps the planted `503` result inline and makes the other 98 long rows
 retrievable by hash. Run it with `python examples/lossy_pruning.py`.
+The versioned inputs and source provenance for these headline figures live in
+[`tests/fixtures/readme_metrics.json`](tests/fixtures/readme_metrics.json).
 
 ### Fine-tuned relevance ranking
 
-[Tokenfold Select][tokenfold-select] is the optional query-aware model for
+[Tokenfold Select][tokenfold-select] is an optional external query-aware model for
 choosing what fills a tight context window after structural compression ends.
+It is distributed and evaluated separately; Tokenfold Core does not invoke it.
 
 | Token budget kept | Tokenfold Select task success | BM25 reference | Lift |
 | ---: | ---: | ---: | ---: |
@@ -48,6 +51,8 @@ three-seed repeated subsampling over roughly 73,000 training and 24,000
 held-out fixtures per run; the [model card][tokenfold-select] publishes the
 training recipe and full baseline set. Here, task success means the literal
 gold answer survived selection under the stated budget.
+These are source-reported external results, pinned by model revision in the
+[metric manifest](tests/fixtures/readme_metrics.json); Core CI does not reproduce them.
 
 ## One platform, two engines
 
@@ -82,7 +87,7 @@ cargo add tokenfold-core    # Rust library
 cargo install tokenfold-cli # Rust CLI
 ```
 
-Or download a signed CLI build for Linux, macOS, or Windows from
+Or download a checksummed CLI build for Linux, macOS, or Windows from
 [GitHub Releases](https://github.com/snchimata/tokenfold/releases/latest) and
 verify it with the adjacent `.sha256` file.
 
@@ -214,9 +219,8 @@ const original = await retrieve(hash); // any dropped row, verbatim
 <summary><strong>Current Phase 1 constraints</strong></summary>
 
 Treat `$tf_ref` as reserved and do not enable lossy pruning on documents that
-already contain retrieval markers. A filesystem failure after partial writes
-may also leave unreferenced entries until their configured TTL expires. Both
-require location-based transactional materialization before promotion.
+already contain retrieval markers. Filesystem entries are published under a
+cross-process lock, and a refused batch leaves every candidate inline.
 
 Preview is a projection rather than a filesystem transaction, so a real run may
 keep more rows if storage becomes unavailable.
@@ -230,8 +234,8 @@ keep more rows if storage becomes unavailable.
 Tokenfold Select is an Apache-2.0 LoRA adapter on
 `ibm-granite/granite-embedding-reranker-english-r2`. It scores candidate spans
 against a query; your allocator applies the token budget and force-keeps
-required content. Core remains model-free and deterministic, while Select adds
-relevance when lexical heuristics stop being enough.
+required content. It is a separately distributed companion: Core remains
+model-free and deterministic and neither loads nor invokes Select.
 
 | | Tokenfold Core | Tokenfold Select |
 | --- | --- | --- |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,16 @@
+# Security policy
+
+## Supported versions
+
+Security fixes are provided for the latest published Tokenfold release. Upgrade to the newest
+patch release before reporting behavior that may already be fixed.
+
+## Reporting a vulnerability
+
+Please report suspected vulnerabilities privately through
+[GitHub Security Advisories](https://github.com/snchimata/tokenfold/security/advisories/new).
+Do not open a public issue for an unpatched vulnerability.
+
+Include the affected version and surface, reproduction steps, expected impact, and any known
+workarounds. Do not include real credentials, secrets, or sensitive customer payloads. You should
+receive an acknowledgement through the advisory within seven days.

--- a/crates/tokenfold-cli/src/main.rs
+++ b/crates/tokenfold-cli/src/main.rs
@@ -163,13 +163,13 @@ enum Command {
         #[command(subcommand)]
         action: McpAction,
     },
-    /// Restore an original payload stored via `--store-originals`.
+    /// Restore an original payload stored by `--store-originals` or recoverable lossy pruning.
     Retrieve {
-        /// A raw hex SHA-256 hash, a `[tokenfold:retrieve ...]` marker, or a path to a
-        /// `CompressionReport` JSON file.
+        /// A raw SHA-256 hash, legacy `[tokenfold:retrieve ...]` marker, serialized JSON
+        /// `$tf_ref` marker, or `CompressionReport` path (reports without a hash are rejected).
         reference: String,
         /// Namespace to look the hash up under; defaults to the resolved `[retrieval]`
-        /// namespace (or the marker's own `namespace=` field, when the reference is a marker).
+        /// namespace, or the marker's embedded namespace when present.
         #[arg(long = "retrieve-namespace")]
         retrieve_namespace: Option<String>,
     },

--- a/crates/tokenfold-cli/src/main.rs
+++ b/crates/tokenfold-cli/src/main.rs
@@ -1457,10 +1457,11 @@ fn cmd_retrieve(
         };
     }
 
-    let (hash, marker_namespace) = parse_retrieve_reference(&reference)?;
+    let parsed = tokenfold_core::retrieval_store::parse_retrieval_reference(&reference)?;
     let namespace = namespace_flag
-        .or(marker_namespace)
+        .or(parsed.namespace)
         .unwrap_or(resolved.effective.retrieval_namespace);
+    let hash = parsed.hash;
 
     let store = tokenfold_core::retrieval_store::RetrievalStore::open(
         &resolved.effective.retrieval_backend,
@@ -1483,34 +1484,6 @@ fn cmd_retrieve(
             Ok(1)
         }
     }
-}
-
-/// Accepts a raw hex SHA-256 hash or a `[tokenfold:retrieve hash=<hex> ... namespace=<ns> ...]`
-/// marker, returning the hash and (when the input was a marker carrying one) its namespace.
-fn parse_retrieve_reference(reference: &str) -> Result<(String, Option<String>), TokenFoldError> {
-    if reference.contains("tokenfold:retrieve") {
-        let hash = extract_marker_field(reference, "hash").ok_or_else(|| {
-            TokenFoldError::InvalidInput("retrieval marker has no hash=<hex> field".to_string())
-        })?;
-        let namespace = extract_marker_field(reference, "namespace");
-        return Ok((hash, namespace));
-    }
-    if reference.is_empty() || !reference.chars().all(|c| c.is_ascii_hexdigit()) {
-        return Err(TokenFoldError::InvalidInput(format!(
-            "{reference:?} is not a valid sha256 hex hash, retrieval marker, or existing report file path"
-        )));
-    }
-    Ok((reference.to_ascii_lowercase(), None))
-}
-
-fn extract_marker_field(marker: &str, field: &str) -> Option<String> {
-    let needle = format!("{field}=");
-    let start = marker.find(&needle)? + needle.len();
-    let rest = &marker[start..];
-    let end = rest
-        .find(|c: char| c.is_whitespace() || c == ']')
-        .unwrap_or(rest.len());
-    Some(rest[..end].to_string())
 }
 
 /// Appends redacted ledger metadata for one successful compress/wrap run when

--- a/crates/tokenfold-cli/src/mcp.rs
+++ b/crates/tokenfold-cli/src/mcp.rs
@@ -14,11 +14,8 @@
 //! already documents (`TOKENFOLD_RETRIEVAL_BACKEND`, `TOKENFOLD_RETRIEVAL_STORE_PATH`,
 //! `TOKENFOLD_ANALYTICS_LEDGER_DB`) rather than the full config file.
 //!
-//! Scope cut: `tokenfold_compress`/`tokenfold_inspect`'s own `store_originals` argument still has
-//! no effect (see `tool_input_schema`) — wiring per-request storage into those two tools is
-//! deferred to a future pass. Only the proxy's `/v1/compress` and provider-passthrough routes got
-//! that wiring this pass (via the `X-TokenFold-Store-Originals`/`X-TokenFold-Retrieve-Store`
-//! request headers).
+//! `tokenfold_compress`/`tokenfold_inspect` reject `store_originals=true` until per-request MCP
+//! persistence is implemented, rather than accepting an option that has no effect.
 //!
 //! Transport is newline-delimited JSON-RPC 2.0 over stdio, the standard MCP stdio framing: one
 //! JSON object per line in, one per line out. stdout carries only JSON-RPC messages; logs (none
@@ -30,7 +27,9 @@ use std::io::{BufRead, Write};
 use std::path::PathBuf;
 
 use serde_json::{Value, json};
-use tokenfold_core::retrieval_store::{RetrievalOutcome, RetrievalStore};
+use tokenfold_core::retrieval_store::{
+    RetrievalOutcome, RetrievalStore, parse_retrieval_reference,
+};
 use tokenfold_core::stats::{self, LedgerStore};
 use tokenfold_core::{
     CompressionInput, CompressionMode, CompressionPolicy, InputFormat, TokenFoldError,
@@ -132,7 +131,7 @@ fn tool_input_schema() -> Value {
             "target_tokens": {"type": "integer", "minimum": 0},
             "store_originals": {
                 "type": "boolean",
-                "description": "The local retrieval store now exists (see `tokenfold_retrieve`), but this tool doesn't persist to it yet; currently has no effect here.",
+                "description": "Reserved. `true` is rejected until per-request MCP persistence is implemented.",
             },
         },
     })
@@ -148,7 +147,11 @@ fn retrieve_input_schema() -> Value {
             },
             "marker": {
                 "type": "string",
-                "description": "A `[tokenfold:retrieve hash=<hex> alg=sha256 namespace=<ns> bytes=<n> ttl=<seconds>]` marker string.",
+                "description": "A legacy `[tokenfold:retrieve ...]` marker or serialized JSON `$tf_ref` marker.",
+            },
+            "namespace": {
+                "type": "string",
+                "description": "Namespace override. Takes precedence over a namespace embedded in `marker`.",
             },
             "report_ref": {
                 "type": "string",
@@ -285,6 +288,16 @@ fn build_input(arguments: &Value) -> Result<(CompressionInput, bool), String> {
 }
 
 fn build_policy(arguments: &Value) -> Result<CompressionPolicy, String> {
+    if arguments
+        .get("store_originals")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+    {
+        return Err(
+            "store_originals=true is not implemented for MCP compression; use the CLI or proxy"
+                .to_string(),
+        );
+    }
     let mode = match arguments.get("mode").and_then(Value::as_str) {
         Some(s) => ModeArg::parse(s)?.to_core(),
         None => CompressionMode::Balanced,
@@ -324,14 +337,11 @@ fn run_retrieve(arguments: &Value) -> Result<Value, String> {
     let hash_arg = arguments.get("hash").and_then(Value::as_str);
     let report_ref = arguments.get("report_ref").and_then(Value::as_str);
 
-    let (hash, namespace) = if let Some(marker) = marker {
-        let hash = extract_marker_field(marker, "hash")
-            .ok_or_else(|| "retrieval marker has no hash=<hex> field".to_string())?;
-        let namespace =
-            extract_marker_field(marker, "namespace").unwrap_or_else(|| "default".to_string());
-        (hash, namespace)
+    let explicit_namespace = arguments.get("namespace").and_then(Value::as_str);
+    let reference = if let Some(marker) = marker {
+        parse_retrieval_reference(marker).map_err(|error| error.to_string())?
     } else if let Some(hash) = hash_arg {
-        (hash.to_string(), "default".to_string())
+        parse_retrieval_reference(hash).map_err(|error| error.to_string())?
     } else if report_ref.is_some() {
         // `RetrievalReport` (report.rs) carries no per-entry content hash, so a report
         // reference alone can never be resolved to a stored hash in the current schema —
@@ -345,9 +355,15 @@ fn run_retrieve(arguments: &Value) -> Result<Value, String> {
     } else {
         return Err("at least one of `hash`, `marker`, or `report_ref` is required".to_string());
     };
+    let namespace = explicit_namespace
+        .map(str::to_string)
+        .or(reference.namespace)
+        .unwrap_or_else(|| "default".to_string());
 
     let store = retrieval_store_from_env()?;
-    Ok(retrieve_outcome_to_value(store.retrieve(&hash, &namespace)))
+    Ok(retrieve_outcome_to_value(
+        store.retrieve(&reference.hash, &namespace),
+    ))
 }
 
 /// `source` is honestly always `"local_mcp"`: this tool only ever reads the local retrieval
@@ -362,18 +378,6 @@ fn retrieve_outcome_to_value(outcome: RetrievalOutcome) -> Value {
         RetrievalOutcome::Missing => json!({"status": "missing", "source": "local_mcp"}),
         RetrievalOutcome::Expired => json!({"status": "expired", "source": "local_mcp"}),
     }
-}
-
-/// Extracts `field=<value>` from a `[tokenfold:retrieve hash=<hex> alg=sha256 namespace=<ns>
-/// bytes=<n> ttl=<seconds>]` marker string, stopping at the next whitespace or `]`.
-fn extract_marker_field(marker: &str, field: &str) -> Option<String> {
-    let needle = format!("{field}=");
-    let start = marker.find(&needle)? + needle.len();
-    let rest = &marker[start..];
-    let end = rest
-        .find(|c: char| c.is_whitespace() || c == ']')
-        .unwrap_or(rest.len());
-    Some(rest[..end].to_string())
 }
 
 fn call_stats(arguments: &Value) -> Value {

--- a/crates/tokenfold-cli/src/mcp.rs
+++ b/crates/tokenfold-cli/src/mcp.rs
@@ -189,7 +189,7 @@ fn handle_tools_list() -> Value {
             },
             {
                 "name": "tokenfold_retrieve",
-                "description": "Restore an original payload previously persisted to the local retrieval store, by hash, marker, or report reference. Missing/expired retrieval is explicit, never partial.",
+                "description": "Restore an original payload previously persisted to the local retrieval store, by hash or marker. Missing/expired retrieval is explicit, never partial; report references are reserved but not yet resolvable.",
                 "inputSchema": retrieve_input_schema(),
             },
             {

--- a/crates/tokenfold-cli/tests/mcp.rs
+++ b/crates/tokenfold-cli/tests/mcp.rs
@@ -159,6 +159,27 @@ fn tools_call_rejects_both_content_and_messages() {
 }
 
 #[test]
+fn tools_call_rejects_unimplemented_store_originals_instead_of_ignoring_it() {
+    let request = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": {
+            "name": "tokenfold_compress",
+            "arguments": {"content": "hello", "store_originals": true}
+        }
+    });
+    let responses = run_mcp(&format!("{request}\n"));
+    assert_eq!(responses[0]["result"]["isError"], true);
+    assert!(
+        responses[0]["result"]["content"][0]["text"]
+            .as_str()
+            .unwrap()
+            .contains("not implemented")
+    );
+}
+
+#[test]
 fn unknown_tool_name_is_a_protocol_error_not_a_tool_error() {
     let request = serde_json::json!({
         "jsonrpc": "2.0",
@@ -266,6 +287,38 @@ fn tools_call_retrieve_missing_hash_returns_missing_status_not_a_tool_error() {
     assert_eq!(structured["source"], "local_mcp");
     assert_eq!(responses[0]["result"]["isError"], false);
 
+    std::fs::remove_dir_all(&store_path).ok();
+}
+
+#[test]
+fn tools_call_retrieve_explicit_namespace_overrides_json_marker_namespace() {
+    let store_path = unique_temp_path("retrieve_namespace");
+    let payload = b"stored in the explicit namespace";
+    let store = tokenfold_core::retrieval_store::RetrievalStore::filesystem(&store_path);
+    let stored = store.store(payload, "explicit", None).unwrap();
+    let marker = serde_json::json!({
+        "$tf_ref": {"hash": stored.hash, "alg": "sha256", "namespace": "embedded"}
+    });
+    let request = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": {
+            "name": "tokenfold_retrieve",
+            "arguments": {"marker": marker.to_string(), "namespace": "explicit"}
+        }
+    });
+    let responses = run_mcp_with_env(
+        &format!("{request}\n"),
+        &[(
+            "TOKENFOLD_RETRIEVAL_STORE_PATH",
+            store_path.to_str().unwrap(),
+        )],
+    );
+    assert_eq!(
+        responses[0]["result"]["structuredContent"]["content"],
+        String::from_utf8_lossy(payload).into_owned()
+    );
     std::fs::remove_dir_all(&store_path).ok();
 }
 

--- a/crates/tokenfold-core/benches/THRESHOLDS.toml
+++ b/crates/tokenfold-core/benches/THRESHOLDS.toml
@@ -4,10 +4,9 @@
 # record. Thresholds carry ~1.3-1.5x headroom over the measured baseline for runner variance;
 # tighten once `bench-regression` has run on a dedicated, fixed-spec CI runner.
 #
-# p95 latency — dominated by TiktokenEstimator::o200k_base() reloading BPE ranks on every
-# `compress()` call (the public API doesn't cache the estimator across calls) plus tiktoken-rs's
-# reference BPE merge implementation; not a benchmark artifact. Worth revisiting if p95 becomes
-# release-blocking in practice.
+# p95 latency uses the cached `o200k_base` estimator.
+# immutable tokenizer data is cached after first use, and benchmark warmup excludes that load.
+# The remaining cost is tiktoken-rs's reference BPE merge implementation.
 command_output_under_1mb_p95_ms = 800.0   # measured 528.163
 structured_json_under_2mb_p95_ms = 2500.0 # measured 1693.855
 # Allocation (total bytes passed to GlobalAlloc::alloc during one compress() call, not peak RSS)

--- a/crates/tokenfold-core/src/budget.rs
+++ b/crates/tokenfold-core/src/budget.rs
@@ -17,6 +17,8 @@ pub struct CompressionPolicy {
     pub reserve_output_tokens: usize,
     pub mode: CompressionMode,
     pub task_scope: TaskScope,
+    /// Reserved for a future prompt-cache preservation contract. Any non-`None` value is
+    /// rejected by [`CompressionPolicy::validate`] so it can never silently do nothing.
     pub cache_boundary: Option<CacheBoundary>,
     pub preserve_latest_user_message: bool,
     pub disabled: Vec<String>,
@@ -128,6 +130,11 @@ impl CompressionPolicy {
     /// policy it receives so a hand-built policy can't silently skip the same fail-closed
     /// guarantees a builder-built one gets for free.
     pub fn validate(&self) -> Result<(), TokenFoldError> {
+        if self.cache_boundary.is_some() {
+            return Err(TokenFoldError::ConfigError(
+                "cache_boundary is reserved but not implemented; omit it".to_string(),
+            ));
+        }
         if self.disabled.iter().any(|id| id == "secret_redaction") {
             return Err(TokenFoldError::ConfigError(
                 "secret_redaction cannot be disabled via CompressionPolicy.disabled".to_string(),
@@ -450,6 +457,15 @@ mod tests {
     fn default_mode_is_balanced() {
         let policy = CompressionPolicy::builder().build().unwrap();
         assert_eq!(policy.mode, CompressionMode::Balanced);
+    }
+
+    #[test]
+    fn cache_boundary_is_rejected_instead_of_silently_ignored() {
+        let error = CompressionPolicy::builder()
+            .cache_boundary(CacheBoundary::ByteOffset(10))
+            .build()
+            .unwrap_err();
+        assert!(error.to_string().contains("not implemented"));
     }
 
     #[test]

--- a/crates/tokenfold-core/src/pipeline/mod.rs
+++ b/crates/tokenfold-core/src/pipeline/mod.rs
@@ -1,4 +1,6 @@
 use std::collections::HashMap;
+#[cfg(feature = "tiktoken")]
+use std::sync::OnceLock;
 
 use serde_json::Value;
 
@@ -24,8 +26,12 @@ pub fn compress(
 ) -> Result<CompressionOutput, TokenFoldError> {
     #[cfg(feature = "tiktoken")]
     {
-        if let Ok(estimator) = crate::token_estimator::TiktokenEstimator::o200k_base() {
-            return compress_with_estimator(input, policy, &estimator);
+        static ESTIMATOR: OnceLock<Option<crate::token_estimator::TiktokenEstimator>> =
+            OnceLock::new();
+        if let Some(estimator) =
+            ESTIMATOR.get_or_init(|| crate::token_estimator::TiktokenEstimator::o200k_base().ok())
+        {
+            return compress_with_estimator(input, policy, estimator);
         }
     }
     compress_with_estimator(input, policy, &ByteHeuristicEstimator)
@@ -709,8 +715,8 @@ fn apply_lossy_reduction(
     let mut persisted_bytes = 0usize;
     let mut skipped_bytes = 0usize;
     let mut marker_count = 0usize;
-    for item in &outcome.dropped {
-        if let Some(probe) = &preview_probe {
+    if let Some(probe) = &preview_probe {
+        for item in &outcome.dropped {
             let would_store = probe
                 .store(&item.bytes, &policy.retrieval_namespace, Some(ttl_seconds))
                 .is_ok();
@@ -722,29 +728,38 @@ fn apply_lossy_reduction(
                         "json_prune produced a dropped item that isn't valid JSON: {e}"
                     ))
                 })?;
-                restore.insert(item.hash.clone(), original);
+                restore.insert(item.pointer.clone(), original);
             }
             // Whether or not the probe succeeded, `marker_count`/`persisted_bytes` stay at 0 —
             // nothing was REALLY stored, so the report must still honestly show `retrieval:
             // None` for a preview run; the probe only ever gates the projected OUTPUT/savings.
-            continue;
         }
-        let stored = store.as_ref().and_then(|s| {
-            s.store(&item.bytes, &policy.retrieval_namespace, Some(ttl_seconds))
-                .ok()
-        });
-        match stored {
-            Some(_marker) => {
-                persisted_bytes += item.bytes.len();
-                marker_count += 1;
-            }
-            None => {
+    } else {
+        let entries: Vec<_> = outcome
+            .dropped
+            .iter()
+            .map(|item| {
+                (
+                    item.bytes.as_slice(),
+                    policy.retrieval_namespace.as_str(),
+                    Some(ttl_seconds),
+                )
+            })
+            .collect();
+        let stored_all = store
+            .as_ref()
+            .is_some_and(|store| store.store_batch(&entries).is_ok());
+        if stored_all {
+            persisted_bytes = outcome.dropped.iter().map(|item| item.bytes.len()).sum();
+            marker_count = outcome.dropped.len();
+        } else {
+            for item in &outcome.dropped {
                 let original: Value = serde_json::from_slice(&item.bytes).map_err(|e| {
                     TokenFoldError::InternalError(format!(
                         "json_prune produced a dropped item that isn't valid JSON: {e}"
                     ))
                 })?;
-                restore.insert(item.hash.clone(), original);
+                restore.insert(item.pointer.clone(), original);
                 skipped_bytes += item.bytes.len();
             }
         }
@@ -761,9 +776,7 @@ fn apply_lossy_reduction(
     // silently emitting a larger payload than we started with. Status is decided BEFORE the
     // retrieval report is touched (below): on rollback, `bytes_out` reverts to the original
     // plaintext with zero `$tf_ref` markers in it, so the report must not claim any markers
-    // exist either, even though the underlying `store()` calls above already physically
-    // succeeded — those bytes are real but orphaned (nothing in the output references them),
-    // not a lie, but reporting them as live markers would be.
+    // exist either. Batched publication above ensures a refused set commits no new entries.
     //
     // `json_prune` has no concept of message roles/protected content -- it happily nominates a
     // system message or the latest user turn in an OpenAI/Anthropic `messages` array as prunable

--- a/crates/tokenfold-core/src/retrieval_store.rs
+++ b/crates/tokenfold-core/src/retrieval_store.rs
@@ -41,6 +41,90 @@ pub struct RetrievalMarker {
     pub ttl_seconds: Option<u64>,
 }
 
+/// A validated reference to one stored original. Accepted inputs are a raw SHA-256 hash,
+/// the legacy `[tokenfold:retrieve ...]` marker, or the JSON `{"$tf_ref": ...}` marker
+/// emitted by lossy JSON pruning.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RetrievalReference {
+    pub hash: String,
+    pub namespace: Option<String>,
+}
+
+pub fn parse_retrieval_reference(reference: &str) -> Result<RetrievalReference, TokenFoldError> {
+    let reference = reference.trim();
+    if reference.starts_with('{') {
+        let value: serde_json::Value = serde_json::from_str(reference).map_err(|error| {
+            TokenFoldError::InvalidInput(format!("invalid retrieval JSON marker: {error}"))
+        })?;
+        let marker = value.get("$tf_ref").unwrap_or(&value);
+        let hash = marker
+            .get("hash")
+            .and_then(serde_json::Value::as_str)
+            .ok_or_else(|| {
+                TokenFoldError::InvalidInput(
+                    "retrieval JSON marker has no string hash field".into(),
+                )
+            })?;
+        let alg = marker
+            .get("alg")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("sha256");
+        let namespace = marker
+            .get("namespace")
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_string);
+        return validate_reference(hash, alg, namespace);
+    }
+    if reference.contains("tokenfold:retrieve") {
+        let hash = extract_marker_field(reference, "hash").ok_or_else(|| {
+            TokenFoldError::InvalidInput("retrieval marker has no hash=<hex> field".into())
+        })?;
+        let alg = extract_marker_field(reference, "alg").unwrap_or_else(|| "sha256".into());
+        return validate_reference(&hash, &alg, extract_marker_field(reference, "namespace"));
+    }
+    validate_reference(reference, "sha256", None)
+}
+
+fn validate_reference(
+    hash: &str,
+    alg: &str,
+    namespace: Option<String>,
+) -> Result<RetrievalReference, TokenFoldError> {
+    if alg != "sha256" {
+        return Err(TokenFoldError::InvalidInput(format!(
+            "unsupported retrieval hash algorithm {alg:?}; expected \"sha256\""
+        )));
+    }
+    if hash.len() != 64 || !hash.chars().all(|c| c.is_ascii_hexdigit()) {
+        return Err(TokenFoldError::InvalidInput(format!(
+            "{hash:?} is not a valid SHA-256 hex hash"
+        )));
+    }
+    if namespace
+        .as_deref()
+        .is_some_and(|value| !is_safe_path_component(value))
+    {
+        return Err(TokenFoldError::InvalidInput(format!(
+            "invalid retrieval namespace: {:?}",
+            namespace.as_deref().unwrap_or_default()
+        )));
+    }
+    Ok(RetrievalReference {
+        hash: hash.to_ascii_lowercase(),
+        namespace,
+    })
+}
+
+fn extract_marker_field(marker: &str, field: &str) -> Option<String> {
+    let needle = format!("{field}=");
+    let start = marker.find(&needle)? + needle.len();
+    let rest = &marker[start..];
+    let end = rest
+        .find(|c: char| c.is_whitespace() || c == ']')
+        .unwrap_or(rest.len());
+    Some(rest[..end].to_string())
+}
+
 /// Result of a retrieval lookup. Deliberately has no "partial" variant: a caller either gets
 /// the exact original bytes back, or an explicit reason it did not.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -787,6 +871,45 @@ mod tests {
         assert_eq!(
             store.retrieve("deadbeef", "../escape"),
             RetrievalOutcome::Missing
+        );
+    }
+
+    #[test]
+    fn parses_all_supported_retrieval_reference_forms() {
+        let hash = "A".repeat(64);
+        let raw = parse_retrieval_reference(&hash).unwrap();
+        assert_eq!(raw.hash, "a".repeat(64));
+        assert_eq!(raw.namespace, None);
+
+        let legacy = parse_retrieval_reference(&format!(
+            "[tokenfold:retrieve hash={hash} alg=sha256 namespace=project bytes=1]"
+        ))
+        .unwrap();
+        assert_eq!(legacy.namespace.as_deref(), Some("project"));
+
+        let json = parse_retrieval_reference(&format!(
+            r#"{{"$tf_ref":{{"hash":"{hash}","alg":"sha256","namespace":"project"}}}}"#
+        ))
+        .unwrap();
+        assert_eq!(json, legacy);
+    }
+
+    #[test]
+    fn rejects_malformed_retrieval_references() {
+        assert!(parse_retrieval_reference("deadbeef").is_err());
+        assert!(
+            parse_retrieval_reference(&format!(
+                "[tokenfold:retrieve hash={} alg=blake3]",
+                "a".repeat(64)
+            ))
+            .is_err()
+        );
+        assert!(
+            parse_retrieval_reference(&format!(
+                r#"{{"$tf_ref":{{"hash":"{}","namespace":"../escape"}}}}"#,
+                "a".repeat(64)
+            ))
+            .is_err()
         );
     }
 }

--- a/crates/tokenfold-core/src/retrieval_store.rs
+++ b/crates/tokenfold-core/src/retrieval_store.rs
@@ -14,8 +14,11 @@
 //! scope cut.
 
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::fs::{File, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
 use std::sync::Mutex;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
@@ -128,55 +131,71 @@ impl RetrievalStore {
         namespace: &str,
         ttl_seconds: Option<u64>,
     ) -> Result<RetrievalMarker, TokenFoldError> {
-        if redaction::contains_secret(bytes) {
-            return Err(TokenFoldError::SafetyViolation(
-                "refusing to persist bytes that match a secret-redaction pattern".to_string(),
-            ));
-        }
-        if !is_safe_path_component(namespace) {
-            return Err(TokenFoldError::InvalidInput(format!(
-                "invalid retrieval namespace: {namespace:?}"
-            )));
-        }
+        self.store_batch(&[(bytes, namespace, ttl_seconds)])
+            .map(|mut markers| markers.remove(0))
+    }
 
-        let hash = hex_sha256(bytes);
-        let meta = EntryMeta {
-            stored_at_unix: now_unix(),
-            ttl_seconds,
-            bytes: bytes.len(),
-        };
+    /// Stores a set as one publication unit. On failure, no newly-created entry remains.
+    pub fn store_batch(
+        &self,
+        entries: &[(&[u8], &str, Option<u64>)],
+    ) -> Result<Vec<RetrievalMarker>, TokenFoldError> {
+        let prepared: Vec<_> = entries
+            .iter()
+            .map(|(bytes, namespace, ttl_seconds)| {
+                validate_store_input(bytes, namespace)?;
+                let hash = hex_sha256(bytes);
+                let meta = EntryMeta {
+                    stored_at_unix: now_unix(),
+                    ttl_seconds: *ttl_seconds,
+                    bytes: bytes.len(),
+                };
+                let marker = RetrievalMarker {
+                    hash,
+                    alg: "sha256",
+                    namespace: (*namespace).to_string(),
+                    bytes: bytes.len(),
+                    ttl_seconds: *ttl_seconds,
+                };
+                Ok((bytes.to_vec(), meta, marker))
+            })
+            .collect::<Result<_, TokenFoldError>>()?;
 
         match self {
             RetrievalStore::Memory(map) => {
                 let mut guard = map.lock().unwrap_or_else(|e| e.into_inner());
-                guard.insert(
-                    (namespace.to_string(), hash.clone()),
-                    MemoryEntry {
-                        bytes: bytes.to_vec(),
-                        meta,
-                    },
-                );
+                for (bytes, meta, marker) in &prepared {
+                    guard.insert(
+                        (marker.namespace.clone(), marker.hash.clone()),
+                        MemoryEntry {
+                            bytes: bytes.clone(),
+                            meta: meta.clone(),
+                        },
+                    );
+                }
             }
             RetrievalStore::Filesystem { root } => {
-                let dir = root.join(namespace);
-                std::fs::create_dir_all(&dir)?;
-                std::fs::write(dir.join(format!("{hash}.bin")), bytes)?;
-                let meta_json = serde_json::to_vec_pretty(&meta).map_err(|e| {
-                    TokenFoldError::InternalError(format!(
-                        "failed to encode retrieval metadata: {e}"
-                    ))
-                })?;
-                std::fs::write(dir.join(format!("{hash}.meta.json")), meta_json)?;
+                std::fs::create_dir_all(root)?;
+                let _lock = lock_store(root)?;
+                let mut created = Vec::new();
+                for (bytes, meta, marker) in &prepared {
+                    match store_filesystem_entry(root, bytes, meta, marker) {
+                        Ok(true) => created.push((marker.namespace.clone(), marker.hash.clone())),
+                        Ok(false) => {}
+                        Err(error) => {
+                            for (namespace, hash) in created {
+                                let dir = root.join(namespace);
+                                std::fs::remove_file(dir.join(format!("{hash}.meta.json"))).ok();
+                                std::fs::remove_file(dir.join(format!("{hash}.bin"))).ok();
+                            }
+                            return Err(error);
+                        }
+                    }
+                }
             }
         }
 
-        Ok(RetrievalMarker {
-            hash,
-            alg: "sha256",
-            namespace: namespace.to_string(),
-            bytes: bytes.len(),
-            ttl_seconds,
-        })
+        Ok(prepared.into_iter().map(|(_, _, marker)| marker).collect())
     }
 
     /// Looks up `hash` in `namespace`. Never returns a partial result: exactly one of
@@ -196,6 +215,12 @@ impl RetrievalStore {
                 }
             }
             RetrievalStore::Filesystem { root } => {
+                if !root.is_dir() {
+                    return RetrievalOutcome::Missing;
+                }
+                let Ok(_lock) = lock_store(root) else {
+                    return RetrievalOutcome::Missing;
+                };
                 let dir = root.join(namespace);
                 let meta_path = dir.join(format!("{hash}.meta.json"));
                 let data_path = dir.join(format!("{hash}.bin"));
@@ -262,6 +287,7 @@ impl RetrievalStore {
                 if !root.is_dir() {
                     return Ok(outcome);
                 }
+                let _lock = lock_store(root)?;
 
                 let mut live: Vec<(PathBuf, PathBuf, EntryMeta)> = Vec::new();
                 for ns_entry in std::fs::read_dir(root)? {
@@ -315,6 +341,111 @@ impl RetrievalStore {
             }
         }
     }
+}
+
+fn validate_store_input(bytes: &[u8], namespace: &str) -> Result<(), TokenFoldError> {
+    if redaction::contains_secret(bytes) {
+        return Err(TokenFoldError::SafetyViolation(
+            "refusing to persist bytes that match a secret-redaction pattern".to_string(),
+        ));
+    }
+    if !is_safe_path_component(namespace) {
+        return Err(TokenFoldError::InvalidInput(format!(
+            "invalid retrieval namespace: {namespace:?}"
+        )));
+    }
+    Ok(())
+}
+
+fn lock_store(root: &Path) -> Result<File, TokenFoldError> {
+    std::fs::create_dir_all(root)?;
+    let file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(root.join(".tokenfold.lock"))?;
+    file.lock()?;
+    Ok(file)
+}
+
+static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+fn unique_sidecar(path: &Path, label: &str) -> PathBuf {
+    let id = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("entry");
+    path.with_file_name(format!(".{name}.{}.{}.{label}", std::process::id(), id))
+}
+
+fn stage_file(path: &Path, bytes: &[u8]) -> Result<PathBuf, TokenFoldError> {
+    let temp = unique_sidecar(path, "tmp");
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&temp)?;
+    if let Err(error) = file.write_all(bytes).and_then(|_| file.sync_all()) {
+        std::fs::remove_file(&temp).ok();
+        return Err(error.into());
+    }
+    Ok(temp)
+}
+
+fn publish_file(temp: &Path, destination: &Path) -> Result<(), TokenFoldError> {
+    let backup = unique_sidecar(destination, "bak");
+    let had_destination = destination.exists();
+    if had_destination {
+        std::fs::rename(destination, &backup)?;
+    }
+    if let Err(error) = std::fs::rename(temp, destination) {
+        if had_destination {
+            std::fs::rename(&backup, destination).ok();
+        }
+        std::fs::remove_file(temp).ok();
+        return Err(error.into());
+    }
+    if had_destination {
+        std::fs::remove_file(backup).ok();
+    }
+    Ok(())
+}
+
+fn store_filesystem_entry(
+    root: &Path,
+    bytes: &[u8],
+    meta: &EntryMeta,
+    marker: &RetrievalMarker,
+) -> Result<bool, TokenFoldError> {
+    let dir = root.join(&marker.namespace);
+    std::fs::create_dir_all(&dir)?;
+    let data_path = dir.join(format!("{}.bin", marker.hash));
+    let meta_path = dir.join(format!("{}.meta.json", marker.hash));
+    let existed = data_path.is_file() && meta_path.is_file();
+    if !existed {
+        std::fs::remove_file(&data_path).ok();
+        std::fs::remove_file(&meta_path).ok();
+    }
+    let meta_json = serde_json::to_vec_pretty(meta).map_err(|e| {
+        TokenFoldError::InternalError(format!("failed to encode retrieval metadata: {e}"))
+    })?;
+    let data_temp = stage_file(&data_path, bytes)?;
+    let meta_temp = match stage_file(&meta_path, &meta_json) {
+        Ok(path) => path,
+        Err(error) => {
+            std::fs::remove_file(data_temp).ok();
+            return Err(error);
+        }
+    };
+    if let Err(error) = publish_file(&data_temp, &data_path) {
+        std::fs::remove_file(meta_temp).ok();
+        return Err(error);
+    }
+    if let Err(error) = publish_file(&meta_temp, &meta_path) {
+        if !existed {
+            std::fs::remove_file(data_path).ok();
+        }
+        return Err(error);
+    }
+    Ok(!existed)
 }
 
 fn is_expired(meta: &EntryMeta) -> bool {
@@ -572,6 +703,56 @@ mod tests {
         assert!(matches!(err, TokenFoldError::SafetyViolation(_)));
         // Nothing should have been written to disk.
         assert!(!root.join("default").exists());
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn filesystem_batch_failure_commits_no_new_entries() {
+        let root = temp_root("batch_rollback");
+        let store = RetrievalStore::filesystem(&root);
+        let entries = [
+            (b"safe first".as_slice(), "default", None),
+            (
+                b"Authorization: Bearer abcDEF123.token-value".as_slice(),
+                "default",
+                None,
+            ),
+        ];
+        assert!(store.store_batch(&entries).is_err());
+        assert_eq!(
+            store.retrieve(&hex_sha256(b"safe first"), "default"),
+            RetrievalOutcome::Missing
+        );
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn filesystem_store_and_gc_do_not_expose_partial_entries() {
+        let root = temp_root("store_gc_race");
+        let store = std::sync::Arc::new(RetrievalStore::filesystem(&root));
+        let writer = {
+            let store = std::sync::Arc::clone(&store);
+            std::thread::spawn(move || {
+                for i in 0..50 {
+                    let bytes = format!("entry-{i}-{}", "x".repeat(256));
+                    let marker = store.store(bytes.as_bytes(), "default", None).unwrap();
+                    assert_eq!(
+                        store.retrieve(&marker.hash, "default"),
+                        RetrievalOutcome::Found(bytes.into_bytes())
+                    );
+                }
+            })
+        };
+        let collector = {
+            let store = std::sync::Arc::clone(&store);
+            std::thread::spawn(move || {
+                for _ in 0..50 {
+                    store.gc(None).unwrap();
+                }
+            })
+        };
+        writer.join().unwrap();
+        collector.join().unwrap();
         std::fs::remove_dir_all(&root).ok();
     }
 

--- a/crates/tokenfold-core/src/transforms/json_prune.rs
+++ b/crates/tokenfold-core/src/transforms/json_prune.rs
@@ -91,6 +91,8 @@ pub struct LossyOptions {
 pub struct DroppedItem {
     pub hash: String,
     pub bytes: Vec<u8>,
+    /// RFC 6901 pointer to the exact marker generated for this item.
+    pub pointer: String,
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -126,7 +128,7 @@ pub fn prune(
     let value: Value = serde_json::from_slice(input)?;
 
     let mut arrays = Vec::new();
-    collect_eligible_arrays(&value, String::new(), &mut arrays);
+    collect_eligible_arrays(&value, String::new(), String::new(), &mut arrays);
     if arrays.is_empty() {
         return Ok(None);
     }
@@ -351,6 +353,7 @@ pub fn prune(
                     ),
                     bytes: serde_json::to_vec(&arrays[array_idx].items[item_idx])
                         .unwrap_or_default(),
+                    pointer: format!("{}/{}", arrays[array_idx].pointer, item_idx),
                 });
             }
         }
@@ -478,6 +481,7 @@ fn marker_json(hash: &str, namespace: &str) -> Value {
 
 struct EligibleArray {
     path: String,
+    pointer: String,
     items: Vec<Value>,
 }
 
@@ -490,17 +494,23 @@ struct EligibleArray {
 /// this cut. Must stay traversal-identical to [`rewrite_tree`] — both increment their cursor in
 /// lockstep over the same `Value`, which is how the two passes stay correlated without needing a
 /// separate stable identity per array instance.
-fn collect_eligible_arrays(value: &Value, path: String, out: &mut Vec<EligibleArray>) {
+fn collect_eligible_arrays(
+    value: &Value,
+    path: String,
+    pointer: String,
+    out: &mut Vec<EligibleArray>,
+) {
     match value {
         Value::Array(items) if items.len() >= MIN_ARRAY_LEN => {
             out.push(EligibleArray {
                 path,
+                pointer,
                 items: items.clone(),
             });
         }
         Value::Array(items) => {
-            for item in items {
-                collect_eligible_arrays(item, path.clone(), out);
+            for (index, item) in items.iter().enumerate() {
+                collect_eligible_arrays(item, path.clone(), format!("{pointer}/{index}"), out);
             }
         }
         Value::Object(map) => {
@@ -510,7 +520,8 @@ fn collect_eligible_arrays(value: &Value, path: String, out: &mut Vec<EligibleAr
                 } else {
                     format!("{path}.{k}")
                 };
-                collect_eligible_arrays(v, child_path, out);
+                let escaped = k.replace('~', "~0").replace('/', "~1");
+                collect_eligible_arrays(v, child_path, format!("{pointer}/{escaped}"), out);
             }
         }
         _ => {}
@@ -567,33 +578,18 @@ fn rewrite_tree(
     }
 }
 
-/// Puts specific dropped items back, keyed by content hash — the fail-closed half of the
+/// Puts specific dropped items back at their generated markers' JSON pointers — the fail-closed half of the
 /// contract (`pipeline::apply_lossy_reduction`): an item whose `RetrievalStore::store` call
 /// failed must not be silently lost, so the caller restores it here rather than leaving its
-/// `$tf_ref` marker in place. Recognizes exactly the marker shape [`marker_json`] builds; any
-/// other node (including one that merely looks similar) is left untouched.
+/// `$tf_ref` marker in place. Location identity keeps unrelated pre-existing markers untouched.
 pub fn revert_markers(json: &Value, restore: &std::collections::HashMap<String, Value>) -> Value {
-    if let Value::Object(map) = json
-        && map.len() == 1
-        && let Some(Value::Object(inner)) = map.get("$tf_ref")
-        && let Some(Value::String(hash)) = inner.get("hash")
-        && let Some(original) = restore.get(hash)
-    {
-        return original.clone();
-    }
-    match json {
-        Value::Array(items) => {
-            Value::Array(items.iter().map(|v| revert_markers(v, restore)).collect())
+    let mut out = json.clone();
+    for (pointer, original) in restore {
+        if let Some(marker) = out.pointer_mut(pointer) {
+            *marker = original.clone();
         }
-        Value::Object(map) => {
-            let mut out = Map::new();
-            for (k, v) in map {
-                out.insert(k.clone(), revert_markers(v, restore));
-            }
-            Value::Object(out)
-        }
-        _ => json.clone(),
     }
+    out
 }
 
 /// Minimal dot-separated path match (exact equality, plus one fail-safe fallback) —
@@ -1088,7 +1084,7 @@ mod tests {
         let bytes = serde_json::to_vec(&input).unwrap();
         let mut arrays = Vec::new();
         let value: Value = serde_json::from_slice(&bytes).unwrap();
-        collect_eligible_arrays(&value, String::new(), &mut arrays);
+        collect_eligible_arrays(&value, String::new(), String::new(), &mut arrays);
         assert_eq!(
             arrays.len(),
             1,
@@ -1110,7 +1106,7 @@ mod tests {
         let mut restore = std::collections::HashMap::new();
         let first = &outcome.dropped[0];
         let original: Value = serde_json::from_slice(&first.bytes).unwrap();
-        restore.insert(first.hash.clone(), original.clone());
+        restore.insert(first.pointer.clone(), original.clone());
 
         let reverted = revert_markers(&outcome.json, &restore);
         let s = serde_json::to_string(&reverted).unwrap();
@@ -1119,6 +1115,31 @@ mod tests {
         assert_eq!(s.matches("$tf_ref").count(), remaining_markers);
         let arr = reverted["items"].as_array().unwrap();
         assert!(arr.contains(&original));
+    }
+
+    #[test]
+    fn revert_markers_does_not_replace_a_preexisting_matching_reference() {
+        let item = serde_json::json!({"n": 1, "pad": padding()});
+        let item_bytes = serde_json::to_vec(&item).unwrap();
+        let hash = hex_sha256(&item_bytes);
+        let existing = marker_json(&hash, "default");
+        let input = serde_json::json!({"existing": existing, "items": vec![item; 10]});
+        let outcome = prune(
+            &serde_json::to_vec(&input).unwrap(),
+            &opts(0.1),
+            &ByteHeuristicEstimator,
+        )
+        .unwrap()
+        .unwrap();
+        let first = &outcome.dropped[0];
+        let mut restore = std::collections::HashMap::new();
+        restore.insert(
+            first.pointer.clone(),
+            serde_json::from_slice(&first.bytes).unwrap(),
+        );
+
+        let reverted = revert_markers(&outcome.json, &restore);
+        assert_eq!(reverted["existing"], input["existing"]);
     }
 
     #[test]
@@ -1229,7 +1250,7 @@ mod tests {
         let bytes = serde_json::to_vec(&input).unwrap();
         let value: Value = serde_json::from_slice(&bytes).unwrap();
         let mut arrays = Vec::new();
-        collect_eligible_arrays(&value, String::new(), &mut arrays);
+        collect_eligible_arrays(&value, String::new(), String::new(), &mut arrays);
         let mut paths: Vec<&str> = arrays.iter().map(|a| a.path.as_str()).collect();
         paths.sort_unstable();
         assert_eq!(paths, vec!["a", "b.c"]);

--- a/crates/tokenfold-proxy/src/server.rs
+++ b/crates/tokenfold-proxy/src/server.rs
@@ -23,7 +23,9 @@ use serde_json::{Value, json};
 use tiny_http::{Header, Method, Request, Response, StatusCode};
 use tokenfold_core::budget::CompressionPolicyBuilder;
 use tokenfold_core::report::{CompressionReport, TransformStatus};
-use tokenfold_core::retrieval_store::{RetrievalOutcome, RetrievalStore};
+use tokenfold_core::retrieval_store::{
+    RetrievalOutcome, RetrievalStore, parse_retrieval_reference,
+};
 use tokenfold_core::status::Status;
 use tokenfold_core::{CompressionInput, CompressionMode, CompressionPolicy, InputFormat};
 
@@ -525,14 +527,15 @@ fn resolve_retrieve_reference(
     let report_ref = value.get("report_ref").and_then(Value::as_str);
 
     if let Some(marker) = marker {
-        let hash = extract_marker_field(marker, "hash")
-            .ok_or("retrieval marker has no hash=<hex> field")?;
-        let namespace = extract_marker_field(marker, "namespace")
+        let reference = parse_retrieval_reference(marker).map_err(|error| error.to_string())?;
+        let namespace = reference
+            .namespace
             .unwrap_or_else(|| default_namespace.to_string());
-        return Ok((hash, namespace));
+        return Ok((reference.hash, namespace));
     }
     if let Some(hash) = hash {
-        return Ok((hash.to_string(), default_namespace.to_string()));
+        let reference = parse_retrieval_reference(hash).map_err(|error| error.to_string())?;
+        return Ok((reference.hash, default_namespace.to_string()));
     }
     if report_ref.is_some() {
         // `RetrievalReport` (tokenfold_core::report) carries no per-entry content hash, so a
@@ -545,19 +548,6 @@ fn resolve_retrieve_reference(
         );
     }
     Err("exactly one of `marker`, `hash`, or `report_ref` is required".to_string())
-}
-
-/// Extracts `field=<value>` from a retrieval marker of the form
-/// `[tokenfold:retrieve hash=<hex> alg=<alg> namespace=<ns> bytes=<n> ttl=<seconds>]`,
-/// stopping at the next whitespace or `]`.
-fn extract_marker_field(marker: &str, field: &str) -> Option<String> {
-    let needle = format!("{field}=");
-    let start = marker.find(&needle)? + needle.len();
-    let rest = &marker[start..];
-    let end = rest
-        .find(|c: char| c.is_whitespace() || c == ']')
-        .unwrap_or(rest.len());
-    Some(rest[..end].to_string())
 }
 
 /// `source` is honestly `"proxy_store"`: this is the proxy's own retrieval store, not the MCP
@@ -609,15 +599,16 @@ fn handle_retrieve_get(
     path: &str,
 ) -> (u16, Response<BodyReader>) {
     let hash = path.trim_start_matches("/v1/retrieve/");
-    if hash.is_empty() {
-        return error_response(400, "missing retrieval hash in path");
-    }
+    let hash = match parse_retrieval_reference(hash) {
+        Ok(reference) => reference.hash,
+        Err(error) => return error_response(400, &error.to_string()),
+    };
     let namespace = retrieval_namespace_header(headers);
     let store = match open_retrieval_store(config) {
         Ok(store) => store,
         Err(message) => return error_response(500, &message),
     };
-    retrieve_response(store.retrieve(hash, &namespace))
+    retrieve_response(store.retrieve(&hash, &namespace))
 }
 
 /// `RetrievalStore`'s public API (tokenfold_core::retrieval_store) has no entry-count/byte-total

--- a/crates/tokenfold-proxy/src/server.rs
+++ b/crates/tokenfold-proxy/src/server.rs
@@ -16,6 +16,7 @@
 use std::io::{Cursor, Read};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, mpsc};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use serde_json::{Value, json};
@@ -42,13 +43,37 @@ pub struct ProxyConfig {
 }
 
 pub fn run(config: &ProxyConfig, server: &tiny_http::Server) {
-    for request in server.incoming_requests() {
-        let start = Instant::now();
-        let method = request.method().as_str().to_string();
-        let path = request.url().split('?').next().unwrap_or("").to_string();
-        let status = handle(config, request);
-        log_access(&method, &path, status, start.elapsed());
-    }
+    let workers = std::thread::available_parallelism()
+        .map(usize::from)
+        .unwrap_or(2)
+        .clamp(2, 16);
+    let (tx, rx) = mpsc::sync_channel::<Request>(workers * 2);
+    let rx = Arc::new(Mutex::new(rx));
+
+    std::thread::scope(|scope| {
+        for _ in 0..workers {
+            let rx = Arc::clone(&rx);
+            scope.spawn(move || {
+                loop {
+                    let request = {
+                        let receiver = rx.lock().unwrap_or_else(|e| e.into_inner());
+                        receiver.recv()
+                    };
+                    let Ok(request) = request else { break };
+                    let start = Instant::now();
+                    let method = request.method().as_str().to_string();
+                    let path = request.url().split('?').next().unwrap_or("").to_string();
+                    let status = handle(config, request);
+                    log_access(&method, &path, status, start.elapsed());
+                }
+            });
+        }
+        for request in server.incoming_requests() {
+            if tx.send(request).is_err() {
+                break;
+            }
+        }
+    });
 }
 
 fn handle(config: &ProxyConfig, mut request: Request) -> u16 {

--- a/crates/tokenfold-proxy/tests/proxy.rs
+++ b/crates/tokenfold-proxy/tests/proxy.rs
@@ -111,14 +111,24 @@ impl Drop for ProxyProcess {
 /// Bare-metal HTTP request over a raw TCP socket, for framing edge cases the high-level `ureq`
 /// client won't let us construct (duplicate/conflicting headers).
 fn raw_request(addr: &str, raw: &str) -> String {
-    let mut stream = TcpStream::connect(addr).unwrap();
-    stream.write_all(raw.as_bytes()).unwrap();
-    stream
-        .set_read_timeout(Some(Duration::from_secs(2)))
-        .unwrap();
-    let mut response = String::new();
-    let _ = stream.read_to_string(&mut response);
-    response
+    // Windows intermittently drops these deliberately malformed sockets when several raw
+    // clients close concurrently. The behavior under test is server framing, not client load.
+    static RAW_REQUEST_LOCK: Mutex<()> = Mutex::new(());
+    let _guard = RAW_REQUEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    for _ in 0..3 {
+        let mut stream = TcpStream::connect(addr).unwrap();
+        stream.write_all(raw.as_bytes()).unwrap();
+        stream
+            .set_read_timeout(Some(Duration::from_secs(5)))
+            .unwrap();
+        let mut response = String::new();
+        let _ = stream.read_to_string(&mut response);
+        if !response.is_empty() {
+            return response;
+        }
+        thread::sleep(Duration::from_millis(20));
+    }
+    String::new()
 }
 
 // ---- startup validation ----
@@ -363,6 +373,56 @@ fn sse_response_passes_through_with_event_stream_content_type() {
         .unwrap();
     assert!(text.contains("data: first"));
     assert!(text.contains("data: [DONE]"));
+}
+
+#[test]
+fn held_open_sse_does_not_block_health_checks() {
+    struct SlowBody(bool);
+    impl Read for SlowBody {
+        fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+            if !self.0 {
+                self.0 = true;
+                let chunk = b"data: first\n\n";
+                buf[..chunk.len()].copy_from_slice(chunk);
+                return Ok(chunk.len());
+            }
+            thread::sleep(Duration::from_secs(2));
+            Ok(0)
+        }
+    }
+
+    let upstream = tiny_http::Server::http("127.0.0.1:0").unwrap();
+    let upstream_addr = upstream.server_addr().to_string();
+    thread::spawn(move || {
+        if let Ok(request) = upstream.recv() {
+            let headers = vec![Header::from_bytes("Content-Type", "text/event-stream").unwrap()];
+            let _ = request.respond(Response::new(
+                StatusCode(200),
+                headers,
+                SlowBody(false),
+                None,
+                None,
+            ));
+        }
+    });
+    let proxy = ProxyProcess::start(&format!("http://{upstream_addr}"), &[]);
+    let stream_url = proxy.url("/v1/chat/completions");
+    let stream = thread::spawn(move || {
+        let mut response = ureq::get(stream_url).call().unwrap();
+        let mut body = String::new();
+        response
+            .body_mut()
+            .as_reader()
+            .read_to_string(&mut body)
+            .unwrap();
+        body
+    });
+
+    thread::sleep(Duration::from_millis(200));
+    let start = std::time::Instant::now();
+    assert_eq!(ureq::get(proxy.url("/livez")).call().unwrap().status(), 200);
+    assert!(start.elapsed() < Duration::from_secs(1));
+    assert!(stream.join().unwrap().contains("data: first"));
 }
 
 // ---- CL.TE / TE.CL smuggling defense ----

--- a/crates/tokenfold-proxy/tests/proxy.rs
+++ b/crates/tokenfold-proxy/tests/proxy.rs
@@ -517,7 +517,7 @@ fn store_originals_header_then_retrieve_round_trips_via_v1_retrieve() {
     assert_eq!(get_value["content"], payload);
 
     // POST /v1/retrieve { "hash": ... } resolves the same entry.
-    let post_body = serde_json::json!({"hash": hash});
+    let post_body = serde_json::json!({"hash": &hash});
     let mut post_response = ureq::post(proxy.url("/v1/retrieve"))
         .header("Content-Type", "application/json")
         .send(&serde_json::to_vec(&post_body).unwrap())
@@ -532,6 +532,23 @@ fn store_originals_header_then_retrieve_round_trips_via_v1_retrieve() {
     let post_value: serde_json::Value = serde_json::from_str(&post_text).unwrap();
     assert_eq!(post_value["status"], "found");
     assert_eq!(post_value["content"], payload);
+
+    let json_marker = serde_json::json!({
+        "$tf_ref": {"hash": hash, "alg": "sha256", "namespace": "default"}
+    });
+    let marker_body = serde_json::json!({"marker": json_marker.to_string()});
+    let mut marker_response = ureq::post(proxy.url("/v1/retrieve"))
+        .header("Content-Type", "application/json")
+        .send(&serde_json::to_vec(&marker_body).unwrap())
+        .unwrap();
+    let mut marker_text = String::new();
+    marker_response
+        .body_mut()
+        .as_reader()
+        .read_to_string(&mut marker_text)
+        .unwrap();
+    let marker_value: serde_json::Value = serde_json::from_str(&marker_text).unwrap();
+    assert_eq!(marker_value["content"], payload);
 
     std::fs::remove_dir_all(&store_dir).ok();
 }

--- a/crates/tokenfold-py/src/lib.rs
+++ b/crates/tokenfold-py/src/lib.rs
@@ -1021,6 +1021,8 @@ fn compress_messages(
 // `$tf_ref` marker through the `hash` argument. CompressionReport paths remain CLI-only.
 // ---------------------------------------------------------------------------------------
 
+/// Restore bytes by raw SHA-256 hash, legacy text marker, or serialized JSON `$tf_ref` marker.
+/// An explicit `namespace` overrides a namespace embedded in a marker.
 #[pyfunction]
 #[pyo3(signature = (hash, *, namespace=None, backend=None, retrieval_store_path=None, policy=None))]
 fn retrieve(

--- a/crates/tokenfold-py/src/lib.rs
+++ b/crates/tokenfold-py/src/lib.rs
@@ -1017,11 +1017,8 @@ fn compress_messages(
 
 // ---------------------------------------------------------------------------------------
 // retrieve: restores a payload previously persisted by `store_originals=True` or `lossy`,
-// mirroring `tokenfold retrieve <hash>`. Unlike the CLI, this never accepts a text
-// `[tokenfold:retrieve ...]` marker or a CompressionReport file path -- a Python caller
-// working with a `$tf_ref` JSON marker already has it parsed
-// (`marker["$tf_ref"]["hash"]`/`["namespace"]`), so re-implementing the CLI's text-marker
-// grammar here would be redundant, not more convenient.
+// mirroring `tokenfold retrieve`: accepts a raw hash, legacy text marker, or serialized JSON
+// `$tf_ref` marker through the `hash` argument. CompressionReport paths remain CLI-only.
 // ---------------------------------------------------------------------------------------
 
 #[pyfunction]
@@ -1035,7 +1032,10 @@ fn retrieve(
     policy: Option<PyRef<'_, PyCompressionPolicy>>,
 ) -> PyResult<Py<PyBytes>> {
     let base = policy.as_deref().map(|p| &p.0);
+    let reference =
+        tokenfold_core::retrieval_store::parse_retrieval_reference(&hash).map_err(map_err)?;
     let resolved_namespace = namespace
+        .or(reference.namespace)
         .or_else(|| base.map(|p| p.retrieval_namespace.clone()))
         .unwrap_or_else(|| "default".to_string());
     let resolved_backend = backend
@@ -1050,13 +1050,15 @@ fn retrieve(
     let store =
         RetrievalStore::open(&resolved_backend, "sha256", resolved_store_path).map_err(map_err)?;
 
-    match store.retrieve(&hash, &resolved_namespace) {
+    match store.retrieve(&reference.hash, &resolved_namespace) {
         RetrievalOutcome::Found(bytes) => Ok(PyBytes::new(py, &bytes).unbind()),
         RetrievalOutcome::Missing => Err(RetrievalError::new_err(format!(
-            "no stored original found for hash {hash:?} in namespace {resolved_namespace:?}"
+            "no stored original found for hash {:?} in namespace {resolved_namespace:?}",
+            reference.hash
         ))),
         RetrievalOutcome::Expired => Err(RetrievalError::new_err(format!(
-            "stored original for hash {hash:?} in namespace {resolved_namespace:?} has expired"
+            "stored original for hash {:?} in namespace {resolved_namespace:?} has expired",
+            reference.hash
         ))),
     }
 }

--- a/packages/tokenfold/README.md
+++ b/packages/tokenfold/README.md
@@ -28,7 +28,7 @@ const { payload, report } = await compress(feed, {
   lossyRatio: 0.35,        // selection hint, not an enforced budget
   lossyPreserve: ["meta"], // arrays that are never pruned
 });
-const original = await retrieve(hash); // a dropped item's original bytes
+const original = await retrieve(JSON.stringify(marker)); // raw hashes also work
 ```
 
 Pass the same options to `inspect` to preview the projected savings without

--- a/packages/tokenfold/src/index.ts
+++ b/packages/tokenfold/src/index.ts
@@ -265,9 +265,10 @@ export interface RetrieveOptions {
 
 /**
  * Restores the original bytes of something a lossy run dropped, or a `storeOriginals` run saved,
- * mirroring `tokenfold retrieve`. `reference` is either a raw hex SHA-256 hash — a compressed
- * payload's `$tf_ref.hash` — or a `[tokenfold:retrieve hash=... namespace=...]` text marker,
- * whose embedded namespace is used when `options.namespace` is omitted. A CompressionReport
+ * mirroring `tokenfold retrieve`. `reference` is a raw hex SHA-256 hash (a compressed
+ * payload's `$tf_ref.hash`), a `[tokenfold:retrieve hash=... namespace=...]` text marker,
+ * or a serialized JSON `$tf_ref` marker. An embedded namespace is used when
+ * `options.namespace` is omitted. A CompressionReport
  * path is NOT a valid reference: the current report schema carries no per-entry hash, and the
  * CLI rejects it rather than guessing.
  *

--- a/packages/tokenfold/test/api.test.mjs
+++ b/packages/tokenfold/test/api.test.mjs
@@ -188,7 +188,7 @@ test("lossy pruning beats lossless and the planted incident survives", async () 
   }
 });
 
-test("retrieve round-trips a dropped item, by hash and by text marker", async () => {
+test("retrieve round-trips a dropped item by every supported reference form", async () => {
   const { configPath } = throwawayStore();
   const input = await readFile(INCIDENT_FEED);
   const lossy = await compress(input, {
@@ -216,6 +216,9 @@ test("retrieve round-trips a dropped item, by hash and by text marker", async ()
     { configPath },
   );
   assert.deepEqual(byMarker, byHash);
+
+  const byJsonMarker = await retrieve(JSON.stringify({ $tf_ref: marker }), { configPath });
+  assert.deepEqual(byJsonMarker, byHash);
 });
 
 test("retrieve rejects an unknown hash, a malformed reference, and a report path", async () => {

--- a/python-tests/test_binding.py
+++ b/python-tests/test_binding.py
@@ -399,6 +399,23 @@ def test_retrieve_via_policy_matches_explicit_kwargs(tmp_path):
     assert via_policy == via_kwargs
 
 
+def test_retrieve_accepts_a_serialized_json_marker(tmp_path):
+    policy = CompressionPolicy(
+        retrieval_store_path=str(tmp_path),
+        lossy=LossyPath.HEURISTIC,
+        lossy_ratio=0.35,
+    )
+    lossy = compress(INCIDENT_FEED, format=InputFormat.JSON, policy=policy)
+    marker = next(
+        event
+        for event in json.loads(lossy.payload)["events"]
+        if isinstance(event, dict) and "$tf_ref" in event
+    )
+
+    restored = retrieve(json.dumps(marker), policy=policy)
+    assert json.loads(restored) in json.loads(INCIDENT_FEED)["events"]
+
+
 def test_retrieve_raises_for_a_missing_hash(tmp_path):
     with pytest.raises(RetrievalError):
         retrieve("0" * 64, namespace="default", retrieval_store_path=str(tmp_path))

--- a/python-tests/test_readme_claims.py
+++ b/python-tests/test_readme_claims.py
@@ -8,6 +8,7 @@ is no claim to check.
 """
 
 import json
+import hashlib
 import re
 from pathlib import Path
 
@@ -18,6 +19,7 @@ import tokenfold
 REPO_ROOT = Path(__file__).resolve().parent.parent
 README = REPO_ROOT / "README.md"
 FIXTURE = REPO_ROOT / "examples" / "api_response.json"
+METRICS = REPO_ROOT / "tests" / "fixtures" / "readme_metrics.json"
 
 CLAIM = re.compile(
     r"The bundled (\d+)-record API response reports ([\d,]+) → ([\d,]+) tokens,\s+"
@@ -29,8 +31,7 @@ def test_readme_fixture_claim_matches_measurement():
     if not (README.is_file() and FIXTURE.is_file()):
         pytest.skip("repository files not present; nothing to check")
     match = CLAIM.search(README.read_text(encoding="utf-8"))
-    if match is None:
-        pytest.skip("README no longer publishes the fixture claim")
+    assert match is not None, "README fixture claim is missing"
 
     source = FIXTURE.read_text(encoding="utf-8")
     report = tokenfold.compress(source, format=tokenfold.InputFormat.JSON).report
@@ -51,6 +52,10 @@ def test_readme_fixture_claim_matches_measurement():
         f"README claim {claimed} no longer matches measurement {measured}; "
         "update README.md (and re-run examples/quickstart.ipynb) in this change"
     )
+    manifest = json.loads(METRICS.read_text(encoding="utf-8"))
+    provenance = manifest["compression"]["api_responses"]
+    assert provenance["reduction_pct"] == claimed["pct"]
+    assert hashlib.sha256(FIXTURE.read_bytes()).hexdigest() == provenance["sha256"]
 
 
 INCIDENT_FIXTURE = REPO_ROOT / "examples" / "incident_feed.json"
@@ -65,8 +70,7 @@ def test_readme_incident_table_matches_measurement(tmp_path):
     if not (README.is_file() and INCIDENT_FIXTURE.is_file()):
         pytest.skip("repository files not present; nothing to check")
     claimed = INCIDENT_ROW.findall(README.read_text(encoding="utf-8"))
-    if not claimed:
-        pytest.skip("README no longer publishes the incident-feed table")
+    assert claimed, "README incident-feed table is missing"
 
     source = INCIDENT_FIXTURE.read_text(encoding="utf-8")
     measured = []
@@ -95,3 +99,22 @@ def test_readme_incident_table_matches_measurement(tmp_path):
         f"README incident-feed table {claimed} no longer matches measurement {measured}; "
         "update README.md (and re-run examples/quickstart.ipynb) in this change"
     )
+
+
+def test_every_headline_metric_has_versioned_provenance():
+    if not README.is_file():
+        pytest.skip("repository files not present; nothing to check")
+    manifest = json.loads(METRICS.read_text(encoding="utf-8"))
+    readme = README.read_text(encoding="utf-8")
+    compression = manifest["compression"]
+    for name in ("search_rag", "repetitive_json", "api_responses", "tool_schemas"):
+        assert f"{compression[name]['reduction_pct']:.1f}% fewer tokens" in readme
+    for budget, values in manifest["select"]["budgets"].items():
+        ratio = str(int(float(budget) * 100))
+        row = re.compile(
+            rf"\| {ratio}% \| \*\*{values['task_success']:.1f}%\*\* \| "
+            rf"{values['bm25']:.1f}% \| \*\*\+{values['lift']:.1f}%\*\* \|"
+        )
+        assert row.search(readme), f"README Select metric row for {ratio}% is missing or stale"
+    revision = manifest["select"]["model_revision"]
+    assert revision in manifest["select"]["source"]

--- a/tests/fixtures/readme_metrics.json
+++ b/tests/fixtures/readme_metrics.json
@@ -1,0 +1,25 @@
+{
+  "schema_version": 1,
+  "repository_commit": "eabbf63805e137fc4c7a8b74e5f02aef4fb842b7",
+  "compression": {
+    "search_rag": { "reduction_pct": 91.7, "command": "python examples/lossy_pruning.py" },
+    "repetitive_json": { "reduction_pct": 67.6, "source": "CHANGELOG.md benchmark record" },
+    "api_responses": {
+      "reduction_pct": 63.9,
+      "fixture": "examples/api_response.json",
+      "sha256": "91653e687b399362c766760a69bc260c8ef0a1e805825c71602f968cd1c6ef27"
+    },
+    "tool_schemas": { "reduction_pct": 45.6, "source": "crates/tokenfold-core/benches/compression_bench.rs" }
+  },
+  "select": {
+    "status": "external_source_reported",
+    "model_revision": "38778684b6643ce28a2014f214301fddc8a69595",
+    "source": "https://huggingface.co/snchimata/tokenfold-select/blob/38778684b6643ce28a2014f214301fddc8a69595/README.md",
+    "budgets": {
+      "0.50": { "task_success": 86.3, "bm25": 79.4, "lift": 8.7 },
+      "0.25": { "task_success": 70.3, "bm25": 60.7, "lift": 15.8 },
+      "0.10": { "task_success": 39.9, "bm25": 37.7, "lift": 5.8 }
+    },
+    "reproduction_gap": "The external model card does not publish dataset hashes, seeds, dependency revisions, command, or environment; these figures are not reproduced by Core CI."
+  }
+}


### PR DESCRIPTION
## Summary
- make retrieval publication atomic, rollback location-safe, and proxy concurrency bounded
- unify validated raw/legacy/JSON retrieval references across every surface; add MCP namespace support and reject unsupported MCP persistence instead of ignoring it
- cache tokenizer initialization, add Python and Windows CI, pin README metrics, document semantic-quality limits, and add private security reporting
- fail clearly when the reserved `cache_boundary` API is used rather than silently doing nothing

## Validation
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --locked`
- `npm test` (21 passed, 1 platform-package skip)
- rebuilt abi3 wheel and `pytest python-tests -q` (38 passed)
- `python eval/run_fidelity.py --gate --profile smoke-first-consumer` (pass)
- benchmark regression gate (pass)

Closes #9
Closes #10
Closes #15
Closes #16
Closes #17